### PR TITLE
Ref. vng-Realisatie/gemma-zaken#130 -- mogelijke foutantwoorden in OAS

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,4 +16,4 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
-zds-schema
+zds-schema==0.0.33

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,10 +39,10 @@ python-dotenv==0.8.2
 pytz==2018.4
 pyyaml==3.12              # via zds-schema
 raven==6.9.0
-requests==2.19.1          # via coreapi
+requests==2.19.1          # via coreapi, zds-schema
 ruamel.yaml==0.15.40      # via drf-yasg
 six==1.11.0               # via drf-yasg, isodate, pip-tools, python-dateutil
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23             # via requests
-zds-schema==0.0.25
+zds-schema==0.0.33

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -69,4 +69,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.0.22
+zds-schema==0.0.33

--- a/src/drc/api/serializers.py
+++ b/src/drc/api/serializers.py
@@ -4,6 +4,7 @@ Serializers of the Document Registratie Component REST API
 
 from drf_extra_fields.fields import Base64FileField
 from rest_framework import serializers
+from zds_schema.validators import URLValidator
 
 from drc.datamodel.models import (
     EnkelvoudigInformatieObject, ZaakInformatieObject
@@ -49,11 +50,15 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
         extra_kwargs = {
             'url': {
                 'lookup_field': 'uuid',
+            },
+            'informatieobjecttype': {
+                'validators': [URLValidator()],
             }
         }
 
 
 class ZaakInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
+    # TODO: valideer dat ZaakInformatieObject.informatieobjecttype hoort bij zaak.zaaktype
     class Meta:
         model = ZaakInformatieObject
         fields = (

--- a/src/drc/api/tests/test_dso_api_strategy.py
+++ b/src/drc/api/tests/test_dso_api_strategy.py
@@ -1,0 +1,186 @@
+from rest_framework.test import APIRequestFactory, APITestCase
+
+from . import views
+from .utils import reverse
+
+
+class DSOApiStrategyTests(APITestCase):
+
+    def test_api_19_documentation_version(self):
+        url = reverse('schema-json', kwargs={'format': '.json'})
+
+        response = self.client.get(url)
+
+        self.assertIn('application/json', response['Content-Type'])
+
+        doc = response.json()
+
+        if 'swagger' in doc:
+            self.assertGreaterEqual(doc['swagger'], '2.0')
+        elif 'openapi' in doc:
+            self.assertGreaterEqual(doc['openapi'], '3.0.0')
+        else:
+            self.fail('Unknown documentation version')
+
+
+class DSOApi50Tests(APITestCase):
+    """
+    Test the error handling responses (API-50).
+    """
+    maxDiff = None
+    factory = APIRequestFactory()
+
+    def assertErrorResponse(self, view, expected_data: dict):
+        _view = view.as_view()
+        # method doesn't matter since we're using `dispatch`
+        request = self.factory.get('/some/irrelevant/url')
+
+        response = _view(request)
+
+        expected_status = expected_data['status']
+        self.assertEqual(response.status_code, expected_status)
+
+        # can't verify UUID...
+        self.assertTrue(response.data['instance'].startswith('urn:uuid:'))
+        del response.data['instance']
+
+        exc_class = view.exception.__class__.__name__
+        expected_data['type'] = f'URI: http://testserver/ref/fouten/{exc_class}/'
+        self.assertEqual(response.data, expected_data)
+
+    def test_400_error(self):
+        self.assertErrorResponse(
+            views.ValidationErrorView,
+            {
+                'code': 'invalid',
+                'title': 'Invalid input.',
+                'status': 400,
+                'detail': '',
+                'invalid-params': [{
+                    'name': 'foo',
+                    'code': 'validation-error',
+                    'reason': 'Invalid data.',
+                }]
+            }
+        )
+
+    def test_401_error(self):
+        self.assertErrorResponse(
+            views.NotAuthenticatedView,
+            {
+                'code': 'not_authenticated',
+                'title': "Authenticatiegegevens zijn niet opgegeven.",
+                'status': 401,
+                'detail': "Authenticatiegegevens zijn niet opgegeven.",
+            }
+        )
+
+    def test_403_error(self):
+        self.assertErrorResponse(
+            views.PermissionDeniedView,
+            {
+                'code': 'permission_denied',
+                'title': 'Je hebt geen toestemming om deze actie uit te voeren.',
+                'status': 403,
+                'detail': 'This action is not allowed',
+            }
+        )
+
+    def test_404_error(self):
+        self.assertErrorResponse(
+            views.NotFoundView,
+            {
+                'code': 'not_found',
+                'title': "Niet gevonden.",
+                'status': 404,
+                'detail': "Some detail message",
+            }
+        )
+
+    def test_405_error(self):
+        self.assertErrorResponse(
+            views.MethodNotAllowedView,
+            {
+                'code': 'method_not_allowed',
+                'title': 'Methode "{method}" niet toegestaan.',
+                'status': 405,
+                'detail': 'Methode "GET" niet toegestaan.',
+            }
+        )
+
+    def test_406_error(self):
+        self.assertErrorResponse(
+            views.NotAcceptableView,
+            {
+                'code': 'not_acceptable',
+                'title': 'Kan niet voldoen aan de opgegeven Accept header.',
+                'status': 406,
+                'detail': 'Content negotation failed',
+            }
+        )
+
+    def test_409_error(self):
+        self.assertErrorResponse(
+            views.ConflictView,
+            {
+                'code': 'conflict',
+                'title': 'A conflict occurred',
+                'status': 409,
+                'detail': 'The resource was updated, please retrieve it again',
+            }
+        )
+
+    def test_410_error(self):
+        self.assertErrorResponse(
+            views.GoneView,
+            {
+                'code': 'gone',
+                'title': 'The resource is gone',
+                'status': 410,
+                'detail': 'The resource was destroyed',
+            }
+        )
+
+    def test_412_error(self):
+        self.assertErrorResponse(
+            views.PreconditionFailed,
+            {
+                'code': 'precondition_failed',
+                'title': 'Precondition failed',
+                'status': 412,
+                'detail': "Something about CRS",
+            }
+        )
+
+    def test_415_error(self):
+        self.assertErrorResponse(
+            views.UnsupportedMediaTypeView,
+            {
+                'code': 'unsupported_media_type',
+                'title': 'Ongeldige media type "{media_type}" in aanvraag.',
+                'status': 415,
+                'detail': 'This media type is not supported',
+            }
+        )
+
+    def test_429_error(self):
+        self.assertErrorResponse(
+            views.ThrottledView,
+            {
+                'code': 'throttled',
+                'title': 'Aanvraag was verstikt.',
+                'status': 429,
+                'detail': "Too many requests",
+            }
+        )
+
+    def test_500_error(self):
+        self.assertErrorResponse(
+            views.InternalServerErrorView,
+            {
+                'code': 'error',
+                'title': 'Er is een serverfout opgetreden.',
+                'status': 500,
+                'detail': "Everything broke",
+            }
+        )

--- a/src/drc/api/tests/test_enkelvoudiginformatieobject.py
+++ b/src/drc/api/tests/test_enkelvoudiginformatieobject.py
@@ -2,12 +2,12 @@ import uuid
 from base64 import b64encode
 from datetime import date
 
+from django.test import override_settings
 from django.urls import reverse, reverse_lazy
 
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
-from zds_schema.constants import VertrouwelijkheidsAanduiding
 
 from drc.datamodel.models import EnkelvoudigInformatieObject
 from drc.datamodel.tests.factories import EnkelvoudigInformatieObjectFactory
@@ -18,6 +18,7 @@ class EnkelvoudigInformatieObjectAPITests(APITestCase):
 
     list_url = reverse_lazy('enkelvoudiginformatieobject-list', kwargs={'version': '1'})
 
+    @override_settings(LINK_FETCHER='zds_schema.mocks.link_fetcher_200')
     def test_create(self):
         content = {
             'identificatie': uuid.uuid4().hex,
@@ -53,7 +54,10 @@ class EnkelvoudigInformatieObjectAPITests(APITestCase):
         self.assertEqual(stored_object.inhoud.read(), b'some file content')
         self.assertEqual(stored_object.link, 'http://een.link')
         self.assertEqual(stored_object.beschrijving, 'test_beschrijving')
-        self.assertEqual(stored_object.informatieobjecttype, 'https://example.com/ztc/api/v1/catalogus/1/informatieobjecttype/1')
+        self.assertEqual(
+            stored_object.informatieobjecttype,
+            'https://example.com/ztc/api/v1/catalogus/1/informatieobjecttype/1'
+        )
         self.assertEqual(stored_object.vertrouwelijkaanduiding, '')
 
         expected_url = reverse('enkelvoudiginformatieobject-detail', kwargs={

--- a/src/drc/api/tests/test_validation.py
+++ b/src/drc/api/tests/test_validation.py
@@ -1,0 +1,23 @@
+from django.test import override_settings
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+from zds_schema.tests import get_validation_errors
+from zds_schema.validators import URLValidator
+
+from .utils import reverse
+
+
+class EnkelvoudigInformatieObjectTests(APITestCase):
+
+    @override_settings(LINK_FETCHER='zds_schema.mocks.link_fetcher_404')
+    def test_validate_informatieobjecttype_invalid(self):
+        url = reverse('enkelvoudiginformatieobject-list')
+
+        response = self.client.post(url, {
+            'informatieobjecttype': 'https://example.com/informatieobjecttype/foo',
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        error = get_validation_errors(response, 'informatieobjecttype')
+        self.assertEqual(error['code'], URLValidator.code)

--- a/src/drc/api/tests/utils.py
+++ b/src/drc/api/tests/utils.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+from django.urls import reverse as _reverse
+
+
+def reverse(*args, **kwargs):
+    kwargs.setdefault('kwargs', {})
+    kwargs['kwargs']['version'] = settings.REST_FRAMEWORK['DEFAULT_VERSION']
+    return _reverse(*args, **kwargs)

--- a/src/drc/api/tests/views.py
+++ b/src/drc/api/tests/views.py
@@ -1,0 +1,63 @@
+from rest_framework import authentication, exceptions, permissions
+from rest_framework.views import APIView
+from zds_schema.exceptions import Conflict, Gone, PreconditionFailed
+
+
+class BaseErrorView(APIView):
+    authentication_classes = ()
+    permission_classes = ()
+
+    exception = None
+
+    def get(self, request, *args, **kwargs):
+        raise self.exception
+
+
+class ValidationErrorView(BaseErrorView):
+    exception = exceptions.ValidationError({'foo': ["Invalid data."]}, code='validation-error')
+
+
+class NotFoundView(BaseErrorView):
+    exception = exceptions.NotFound("Some detail message")
+
+
+class NotAuthenticatedView(BaseErrorView):
+    authentication_classes = (authentication.BasicAuthentication,)
+    permission_classes = (permissions.IsAuthenticated,)
+    exception = exceptions.NotAuthenticated()
+
+
+class PermissionDeniedView(BaseErrorView):
+    exception = exceptions.PermissionDenied("This action is not allowed")
+
+
+class MethodNotAllowedView(BaseErrorView):
+    exception = exceptions.MethodNotAllowed("GET")
+
+
+class NotAcceptableView(BaseErrorView):
+    exception = exceptions.NotAcceptable("Content negotation failed")
+
+
+class ConflictView(BaseErrorView):
+    exception = Conflict("The resource was updated, please retrieve it again")
+
+
+class GoneView(BaseErrorView):
+    exception = Gone("The resource was destroyed")
+
+
+class PreconditionFailed(BaseErrorView):
+    exception = PreconditionFailed("Something about CRS")
+
+
+class UnsupportedMediaTypeView(BaseErrorView):
+    exception = exceptions.UnsupportedMediaType('application/xml', detail="This media type is not supported")
+
+
+class ThrottledView(BaseErrorView):
+    exception = exceptions.Throttled(detail="Too many requests")
+
+
+class InternalServerErrorView(BaseErrorView):
+    exception = exceptions.APIException("Everything broke")

--- a/src/drc/api/viewsets.py
+++ b/src/drc/api/viewsets.py
@@ -20,6 +20,8 @@ class EnkelvoudigInformatieObjectViewSet(mixins.CreateModelMixin,
     create:
     Registreer een EnkelvoudigInformatieObject.
 
+    De URL naar het informatieobjecttype wordt gevalideerd op geldigheid.
+
     retrieve:
     Geef de details van een EnkelvoudigInformatieObject.
     """

--- a/src/drc/conf/api.py
+++ b/src/drc/conf/api.py
@@ -1,4 +1,6 @@
-from zds_schema.conf.api import BASE_REST_FRAMEWORK, BASE_SWAGGER_SETTINGS
+from zds_schema.conf.api import (  # noqa
+    BASE_REST_FRAMEWORK, BASE_SWAGGER_SETTINGS, LINK_FETCHER
+)
 
 REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
 

--- a/src/drc/conf/api.py
+++ b/src/drc/conf/api.py
@@ -1,76 +1,11 @@
-REST_FRAMEWORK = {
-    'DEFAULT_RENDERER_CLASSES': (
-        'djangorestframework_camel_case.render.CamelCaseJSONRenderer',
-    ),
-    'DEFAULT_PARSER_CLASSES': (
-        'djangorestframework_camel_case.parser.CamelCaseJSONParser',
-    ),
-    # 'DEFAULT_AUTHENTICATION_CLASSES': (
-    #     'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
-    #     # 'rest_framework.authentication.SessionAuthentication',
-    #     # 'rest_framework.authentication.BasicAuthentication'
-    # ),
-    # 'DEFAULT_PERMISSION_CLASSES': (
-    #     'oauth2_provider.contrib.rest_framework.TokenHasReadWriteScope',
-    #     # 'rest_framework.permissions.IsAuthenticated',
-    #     # 'rest_framework.permissions.AllowAny',
-    # ),
-    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
-    #
-    # # Generic view behavior
-    # 'DEFAULT_PAGINATION_CLASS': 'ztc.api.utils.pagination.HALPagination',
-    'DEFAULT_FILTER_BACKENDS': (
-        'zds_schema.filters.Backend',
-    #     'rest_framework.filters.SearchFilter',
-    #     'rest_framework.filters.OrderingFilter',
-    ),
-    #
-    # # Filtering
-    # 'SEARCH_PARAM': 'zoek',  # 'search',
-    # 'ORDERING_PARAM': 'sorteer',  # 'ordering',
-    #
-    # Versioning
-    'DEFAULT_VERSION': '1',
-    'ALLOWED_VERSIONS': ('1', ),
-    'VERSION_PARAM': 'version',
-    #
-    # # Exception handling
-    # 'EXCEPTION_HANDLER': 'ztc.api.utils.exceptions.exception_handler',
-    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
-}
+from zds_schema.conf.api import BASE_REST_FRAMEWORK, BASE_SWAGGER_SETTINGS
 
-SWAGGER_SETTINGS = {
-    # 'SECURITY_DEFINITIONS': {
-    #     'OAuth2': {
-    #         'type': 'oauth2',
-    #         'flow': 'application',
-    #         'tokenUrl': '/oauth2/token/',
-    #         'scopes': {
-    #             'write': 'Schrijftoegang tot de catalogus en gerelateerde objecten.',
-    #             'read': 'Leestoegang tot de catalogus en gerelateerde objecten.'
-    #         }
-    #     },
-    #     'Bearer': {
-    #         'type': 'apiKey',
-    #         'name': 'Authorization',
-    #         'in': 'header'
-    #     },
-    # },
-    'DEFAULT_AUTO_SCHEMA_CLASS': 'zds_schema.schema.AutoSchema',
+REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
+
+
+SWAGGER_SETTINGS = BASE_SWAGGER_SETTINGS.copy()
+SWAGGER_SETTINGS.update({
     'DEFAULT_INFO': 'drc.api.schema.info',
-    'DEFAULT_FIELD_INSPECTORS': (
-        'drf_yasg.inspectors.CamelCaseJSONFilter',
-        'drf_yasg.inspectors.RecursiveFieldInspector',
-        'drf_yasg.inspectors.ReferencingSerializerInspector',
-        'drf_yasg.inspectors.ChoiceFieldInspector',
-        'drf_yasg.inspectors.FileFieldInspector',
-        'drf_yasg.inspectors.DictFieldInspector',
-        'drf_yasg.inspectors.HiddenFieldInspector',
-        'drf_yasg.inspectors.RelatedFieldInspector',
-        'drf_yasg.inspectors.SimpleFieldInspector',
-        'drf_yasg.inspectors.StringDefaultFieldInspector',
-    ),
-    'DEFAULT_FILTER_INSPECTORS': (
-        'zds_schema.inspectors.query.FilterInspector',
-    )
-}
+    # no geo things here
+    'DEFAULT_FIELD_INSPECTORS': BASE_SWAGGER_SETTINGS['DEFAULT_FIELD_INSPECTORS'][1:]
+})

--- a/src/drc/sass/components/_all.scss
+++ b/src/drc/sass/components/_all.scss
@@ -1,3 +1,4 @@
 @import "page-header/all";
 @import "content/all";
 @import "link-block/all";
+@import "error-detail/all";

--- a/src/drc/sass/components/error-detail/_all.scss
+++ b/src/drc/sass/components/error-detail/_all.scss
@@ -1,0 +1,2 @@
+@import "error-detail";
+@import "error-detail-properties";

--- a/src/drc/sass/components/error-detail/_error-detail-properties.scss
+++ b/src/drc/sass/components/error-detail/_error-detail-properties.scss
@@ -1,0 +1,22 @@
+.error-detail-properties {
+  display: flex;
+  flex-wrap: wrap;
+
+  &__property {
+    width: 20%;
+    min-width: 200px;
+    margin: 0;
+    padding: 10px 0;
+
+    font-weight: 700;
+  }
+
+  &__value {
+    width: 80%;
+    margin: 0;
+    padding: 10px 0;
+
+    font-weight: 700;
+    color: $color-code;
+  }
+}

--- a/src/drc/sass/components/error-detail/_error-detail.scss
+++ b/src/drc/sass/components/error-detail/_error-detail.scss
@@ -1,0 +1,13 @@
+@import '../../lib/responsive';
+
+$error-detail-max-width: $breakpoint-laptop-l;
+
+.error-detail {
+  max-width: $error-detail-max-width;
+  margin: 0 auto;
+
+  &__title {
+    color: $color-black;
+    border-bottom: solid 2px $color-vng-blue;
+  }
+}

--- a/src/drc/sass/lib/_color.scss
+++ b/src/drc/sass/lib/_color.scss
@@ -2,3 +2,4 @@ $color-white: #FFF;
 $color-black: #041A34;
 
 $color-vng-blue: #009FE3;
+$color-code: #D14;

--- a/src/drc/templates/zds_schema/error_detail.html
+++ b/src/drc/templates/zds_schema/error_detail.html
@@ -1,0 +1,23 @@
+{% extends "master.html" %}
+{% load staticfiles %}
+
+
+{% block content %}
+<article class="error-detail">
+
+    <h1 class="error-detail__title"><code>{{ type }}</code> fouttype</h1>
+
+    <dl class="error-detail-properties">
+        <dt class="error-detail-properties__property">HTTP Status code</dt>
+        <dd class="error-detail-properties__value"><code>{{ status_code }}</code></dd>
+
+        <dt class="error-detail-properties__property">Default title</dt>
+        <dd class="error-detail-properties__value"><code>{{ default_detail }}</code></dd>
+
+        <dt class="error-detail-properties__property">Default code</dt>
+        <dd class="error-detail-properties__value"><code>{{ default_code }}</code></dd>
+    </dl>
+
+
+</article>
+{% endblock %}

--- a/src/drc/tests/test_userstory_169.py
+++ b/src/drc/tests/test_userstory_169.py
@@ -8,6 +8,8 @@ See:
 import base64
 from io import BytesIO
 
+from django.test import override_settings
+
 from PIL import Image
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -17,6 +19,7 @@ from zds_schema.tests import TypeCheckMixin, get_operation_url
 
 class US169Tests(TypeCheckMixin, APITestCase):
 
+    @override_settings(LINK_FETCHER='zds_schema.mocks.link_fetcher_200')
     def test_upload_image(self):
         url = get_operation_url('enkelvoudiginformatieobject_create')
 

--- a/src/drc/tests/test_userstory_39.py
+++ b/src/drc/tests/test_userstory_39.py
@@ -6,6 +6,7 @@ from datetime import date
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.test import override_settings
 
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -17,6 +18,7 @@ from drc.datamodel.models import EnkelvoudigInformatieObject
 
 class US39TestCase(APITestCase):
 
+    @override_settings(LINK_FETCHER='zds_schema.mocks.link_fetcher_200')
     def test_create_enkelvoudiginformatieobject(self):
         """
         Registreer een ENKELVOUDIGINFORMATIEOBJECT

--- a/src/drc/urls.py
+++ b/src/drc/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
 
     # Simply show the index template.
     path('', TemplateView.as_view(template_name='index.html')),
+    path('ref/', include('zds_schema.urls')),
 ]
 
 # NOTE: The staticfiles_urlpatterns also discovers static files (ie. no need to run collectstatic). Both the static

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -24,6 +24,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/EnkelvoudigInformatieObject'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - enkelvoudiginformatieobjecten
     post:
@@ -36,6 +84,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EnkelvoudigInformatieObject'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - enkelvoudiginformatieobjecten
       requestBody:
@@ -56,6 +158,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EnkelvoudigInformatieObject'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - enkelvoudiginformatieobjecten
     parameters:
@@ -94,6 +250,54 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ZaakInformatieObject'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - zaakinformatieobjecten
     post:
@@ -106,6 +310,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ZaakInformatieObject'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidatieFout'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - zaakinformatieobjecten
       requestBody:
@@ -126,6 +384,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ZaakInformatieObject'
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '406':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '409':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '410':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '415':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '429':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
+        '500':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Fout'
       tags:
         - zaakinformatieobjecten
     parameters:
@@ -732,6 +1044,111 @@ components:
           format: uri
           maxLength: 200
           minLength: 1
+    Fout:
+      required:
+        - code
+        - title
+        - status
+        - detail
+        - instance
+      type: object
+      properties:
+        type:
+          title: Type
+          description: 'URI referentie naar het type fout, bedoeld voor developers'
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: 'Extra informatie bij de fout, indien beschikbaar'
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: >-
+            URI met referentie naar dit specifiek voorkomen van de fout. Deze
+            kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1
+    FieldValidationError:
+      required:
+        - name
+        - code
+        - reason
+      type: object
+      properties:
+        name:
+          title: Name
+          description: Naam van het veld met ongeldige gegevens
+          type: string
+          minLength: 1
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        reason:
+          title: Reason
+          description: Uitleg wat er precies fout is met de gegevens
+          type: string
+          minLength: 1
+    ValidatieFout:
+      required:
+        - code
+        - title
+        - status
+        - detail
+        - instance
+        - invalid-params
+      type: object
+      properties:
+        type:
+          title: Type
+          description: 'URI referentie naar het type fout, bedoeld voor developers'
+          type: string
+        code:
+          title: Code
+          description: Systeemcode die het type fout aangeeft
+          type: string
+          minLength: 1
+        title:
+          title: Title
+          description: Generieke titel voor het type fout
+          type: string
+          minLength: 1
+        status:
+          title: Status
+          description: De HTTP status code
+          type: integer
+        detail:
+          title: Detail
+          description: 'Extra informatie bij de fout, indien beschikbaar'
+          type: string
+          minLength: 1
+        instance:
+          title: Instance
+          description: >-
+            URI met referentie naar dit specifiek voorkomen van de fout. Deze
+            kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          type: string
+          minLength: 1
+        invalid-params:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldValidationError'
     ZaakInformatieObject:
       required:
         - zaak

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -76,7 +76,10 @@ paths:
         - enkelvoudiginformatieobjecten
     post:
       operationId: enkelvoudiginformatieobject_create
-      description: Registreer een EnkelvoudigInformatieObject.
+      description: |-
+        Registreer een EnkelvoudigInformatieObject.
+
+        De URL naar het informatieobjecttype wordt gevalideerd op geldigheid.
       responses:
         '201':
           description: ''

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -44,6 +44,54 @@
                                 "$ref": "#/definitions/EnkelvoudigInformatieObject"
                             }
                         }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -69,6 +117,60 @@
                         "schema": {
                             "$ref": "#/definitions/EnkelvoudigInformatieObject"
                         }
+                    },
+                    "400": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/ValidatieFout"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -87,6 +189,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/EnkelvoudigInformatieObject"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -136,6 +292,54 @@
                                 "$ref": "#/definitions/ZaakInformatieObject"
                             }
                         }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -161,6 +365,60 @@
                         "schema": {
                             "$ref": "#/definitions/ZaakInformatieObject"
                         }
+                    },
+                    "400": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/ValidatieFout"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
                     }
                 },
                 "tags": [
@@ -179,6 +437,60 @@
                         "description": "",
                         "schema": {
                             "$ref": "#/definitions/ZaakInformatieObject"
+                        }
+                    },
+                    "401": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "403": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "404": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "406": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "409": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "410": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "415": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "429": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/Fout"
                         }
                     }
                 },
@@ -787,6 +1099,133 @@
                     "format": "uri",
                     "maxLength": 200,
                     "minLength": 1
+                }
+            }
+        },
+        "Fout": {
+            "required": [
+                "code",
+                "title",
+                "status",
+                "detail",
+                "instance"
+            ],
+            "type": "object",
+            "properties": {
+                "type": {
+                    "title": "Type",
+                    "description": "URI referentie naar het type fout, bedoeld voor developers",
+                    "type": "string"
+                },
+                "code": {
+                    "title": "Code",
+                    "description": "Systeemcode die het type fout aangeeft",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "title": {
+                    "title": "Title",
+                    "description": "Generieke titel voor het type fout",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "status": {
+                    "title": "Status",
+                    "description": "De HTTP status code",
+                    "type": "integer"
+                },
+                "detail": {
+                    "title": "Detail",
+                    "description": "Extra informatie bij de fout, indien beschikbaar",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "instance": {
+                    "title": "Instance",
+                    "description": "URI met referentie naar dit specifiek voorkomen van de fout. Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.",
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "FieldValidationError": {
+            "required": [
+                "name",
+                "code",
+                "reason"
+            ],
+            "type": "object",
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "description": "Naam van het veld met ongeldige gegevens",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "code": {
+                    "title": "Code",
+                    "description": "Systeemcode die het type fout aangeeft",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "reason": {
+                    "title": "Reason",
+                    "description": "Uitleg wat er precies fout is met de gegevens",
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "ValidatieFout": {
+            "required": [
+                "code",
+                "title",
+                "status",
+                "detail",
+                "instance",
+                "invalid-params"
+            ],
+            "type": "object",
+            "properties": {
+                "type": {
+                    "title": "Type",
+                    "description": "URI referentie naar het type fout, bedoeld voor developers",
+                    "type": "string"
+                },
+                "code": {
+                    "title": "Code",
+                    "description": "Systeemcode die het type fout aangeeft",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "title": {
+                    "title": "Title",
+                    "description": "Generieke titel voor het type fout",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "status": {
+                    "title": "Status",
+                    "description": "De HTTP status code",
+                    "type": "integer"
+                },
+                "detail": {
+                    "title": "Detail",
+                    "description": "Extra informatie bij de fout, indien beschikbaar",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "instance": {
+                    "title": "Instance",
+                    "description": "URI met referentie naar dit specifiek voorkomen van de fout. Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "invalid-params": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FieldValidationError"
+                    }
                 }
             }
         },

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -100,7 +100,7 @@
             },
             "post": {
                 "operationId": "enkelvoudiginformatieobject_create",
-                "description": "Registreer een EnkelvoudigInformatieObject.",
+                "description": "Registreer een EnkelvoudigInformatieObject.\n\nDe URL naar het informatieobjecttype wordt gevalideerd op geldigheid.",
                 "parameters": [
                     {
                         "name": "data",


### PR DESCRIPTION
**Wijzigingen**

* Mogelijke responses (HTTP status code) toegevoegd op alle resources:
    * Afhankelijk van de operation (create/read/update/delete/partial_update) een andere set van status codes
    * Formaat van 'generieke' fouten en validatiefouten in OAS schema opgenomen
    * generiek geimplementeerd in vng-Realisatie/gemma-zaken-common
* DSO API-50 tests 
* Tests update naar nieuwe formaat validatie
* Gestylede HTML pagina's voor de typen foutmeldingen
* Gebruik common settings van `zds_schema.conf.api` (minder duplicatie van code/config)

**Links**

[Browsable API spec](http://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/VNG-Realisatie/gemma-documentregistratiecomponent/feature/us-130-error-responses/src/openapi.yaml)

**Checklist**

- [x] API test DSO API-50
- [x] Common status codes getest & geimplementeerd:
    - [x] 400 validation errors
    - [x] 401 Auth creds ontbreken
    - [x] 403 Permission denied
    - [x] 404 NotFound
    - [x] 405 Method not allowed
    - [x] 406 Not Acceptable
    - [x] 409 Conflict
    - [x] 410 Gone
    - [x] 412 Precondition failed
    - [x] 415 Unsupported Media Type
    - [x] ~~422 Unprocessable Entity~~ - zal bij ons concreet een HTTP 400 worden met validatiefouten
    - [x] 429 Too Many Requests
    - [x] 500 Internal Server Error
    - [x] ~~503 Service Unavailable~~ - dit moet op webserver niveau opgelost worden
- [x] Introspectie viewsets & foutberichten komen terecht in `openapi.yaml`
- [x] Documentatie betekenis foutcodes
- [x] Documentatie validaties die toegepast worden (functioneel)