### PR TITLE
Correcte MIME-types voor error responses

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,4 +16,4 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
-zds-schema==0.0.33
+zds-schema==0.3.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,4 +16,4 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
-zds-schema==0.3.0
+zds-schema==0.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,4 +46,4 @@ six==1.11.0               # via drf-yasg, isodate, pip-tools, python-dateutil
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23             # via requests
-zds-schema==0.3.0
+zds-schema==0.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,13 +31,14 @@ itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
 markupsafe==1.0           # via jinja2
 openapi-codec==1.3.2      # via drf-yasg
+oyaml==0.7                # via zds-schema
 pillow==5.2.0
 pip-tools==2.0.2
 psycopg2-binary==2.7.5
 python-dateutil==2.7.3
 python-dotenv==0.8.2
 pytz==2018.4
-pyyaml==3.12              # via zds-schema
+pyyaml==3.12              # via oyaml, zds-schema
 raven==6.9.0
 requests==2.19.1          # via coreapi, zds-schema
 ruamel.yaml==0.15.40      # via drf-yasg
@@ -45,4 +46,4 @@ six==1.11.0               # via drf-yasg, isodate, pip-tools, python-dateutil
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23             # via requests
-zds-schema==0.0.33
+zds-schema==0.3.0

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -70,4 +70,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.3.0
+zds-schema==0.3.1

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -45,6 +45,7 @@ markupsafe==1.0
 mccabe==0.6.1             # via pylint
 mock==2.0.0
 openapi-codec==1.3.2
+oyaml==0.7
 pbr==4.1.0                # via mock
 pep8==1.7.1
 pillow==5.2.0
@@ -69,4 +70,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.0.33
+zds-schema==0.3.0

--- a/src/drc/api/tests/test_dso_api_strategy.py
+++ b/src/drc/api/tests/test_dso_api_strategy.py
@@ -39,7 +39,7 @@ class DSOApi50Tests(APITestCase):
 
         expected_status = expected_data['status']
         self.assertEqual(response.status_code, expected_status)
-        self.assertEqual(response['Content-Type'], 'application/error+json')
+        self.assertEqual(response['Content-Type'], 'application/problem+json')
 
         # can't verify UUID...
         self.assertTrue(response.data['instance'].startswith('urn:uuid:'))

--- a/src/drc/api/tests/test_dso_api_strategy.py
+++ b/src/drc/api/tests/test_dso_api_strategy.py
@@ -39,6 +39,7 @@ class DSOApi50Tests(APITestCase):
 
         expected_status = expected_data['status']
         self.assertEqual(response.status_code, expected_status)
+        self.assertEqual(response['Content-Type'], 'application/error+json')
 
         # can't verify UUID...
         self.assertTrue(response.data['instance'].startswith('urn:uuid:'))

--- a/src/drc/conf/api.py
+++ b/src/drc/conf/api.py
@@ -1,6 +1,4 @@
-from zds_schema.conf.api import (  # noqa
-    BASE_REST_FRAMEWORK, BASE_SWAGGER_SETTINGS, LINK_FETCHER
-)
+from zds_schema.conf.api import *  # noqa - imports white-listed
 
 REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
 
@@ -11,3 +9,5 @@ SWAGGER_SETTINGS.update({
     # no geo things here
     'DEFAULT_FIELD_INSPECTORS': BASE_SWAGGER_SETTINGS['DEFAULT_FIELD_INSPECTORS'][1:]
 })
+
+GEMMA_URL_INFORMATIEMODEL_VERSIE = '1.0'

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3,13 +3,13 @@ info:
   title: Documentregistratiecomponent (drc) API
   description: Een API om een documentregistratiecomponent te benaderen
   contact:
-    url: 'https://github.com/VNG-Realisatie/gemma-zaken'
+    url: https://github.com/VNG-Realisatie/gemma-zaken
     email: support@maykinmedia.nl
   license:
     name: EUPL 1.2
   version: '1'
 security:
-  - basic: []
+- basic: []
 paths:
   /enkelvoudiginformatieobjecten:
     get:
@@ -27,59 +27,59 @@ paths:
         '401':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
-        - enkelvoudiginformatieobjecten
+      - enkelvoudiginformatieobjecten
     post:
       operationId: enkelvoudiginformatieobject_create
-      description: |-
-        Registreer een EnkelvoudigInformatieObject.
+      description: 'Registreer een EnkelvoudigInformatieObject.
 
-        De URL naar het informatieobjecttype wordt gevalideerd op geldigheid.
+
+        De URL naar het informatieobjecttype wordt gevalideerd op geldigheid.'
       responses:
         '201':
           description: ''
@@ -90,59 +90,59 @@ paths:
         '400':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
-        - enkelvoudiginformatieobjecten
+      - enkelvoudiginformatieobjecten
       requestBody:
         content:
           application/json:
@@ -150,7 +150,7 @@ paths:
               $ref: '#/components/schemas/EnkelvoudigInformatieObject'
         required: true
     parameters: []
-  '/enkelvoudiginformatieobjecten/{uuid}':
+  /enkelvoudiginformatieobjecten/{uuid}:
     get:
       operationId: enkelvoudiginformatieobject_read
       description: Geef de details van een EnkelvoudigInformatieObject.
@@ -164,86 +164,86 @@ paths:
         '401':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
-        - enkelvoudiginformatieobjecten
+      - enkelvoudiginformatieobjecten
     parameters:
-      - name: uuid
-        in: path
-        description: Unieke resource identifier (UUID4)
-        required: true
-        schema:
-          type: string
-          format: uuid
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
   /zaakinformatieobjecten:
     get:
       operationId: zaakinformatieobject_list
       description: Beheer relatie tussen InformatieObject en ZAAK.
       parameters:
-        - name: zaak
-          in: query
-          description: URL naar de ZAAK in het ZRC.
-          required: false
-          schema:
-            type: string
-            format: uri
-        - name: informatieobject
-          in: query
-          description: URL to the related resource
-          required: false
-          schema:
-            type: string
-            format: uri
+      - name: zaak
+        in: query
+        description: URL naar de ZAAK in het ZRC.
+        required: false
+        schema:
+          type: string
+          format: uri
+      - name: informatieobject
+        in: query
+        description: URL to the related resource
+        required: false
+        schema:
+          type: string
+          format: uri
       responses:
         '200':
           description: ''
@@ -256,53 +256,53 @@ paths:
         '401':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
-        - zaakinformatieobjecten
+      - zaakinformatieobjecten
     post:
       operationId: zaakinformatieobject_create
       description: Registreer een INFORMATIEOBJECT bij een ZAAK.
@@ -316,59 +316,59 @@ paths:
         '400':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
-        - zaakinformatieobjecten
+      - zaakinformatieobjecten
       requestBody:
         content:
           application/json:
@@ -376,7 +376,7 @@ paths:
               $ref: '#/components/schemas/ZaakInformatieObject'
         required: true
     parameters: []
-  '/zaakinformatieobjecten/{uuid}':
+  /zaakinformatieobjecten/{uuid}:
     get:
       operationId: zaakinformatieobject_read
       description: Geef de details van een ZAAKINFORMATIEOBJECT relatie.
@@ -390,69 +390,69 @@ paths:
         '401':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/json:
+            application/error+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
-        - zaakinformatieobjecten
+      - zaakinformatieobjecten
     parameters:
-      - name: uuid
-        in: path
-        description: Unieke resource identifier (UUID4)
-        required: true
-        schema:
-          type: string
-          format: uuid
+    - name: uuid
+      in: path
+      description: Unieke resource identifier (UUID4)
+      required: true
+      schema:
+        type: string
+        format: uuid
 servers:
-  - url: /api/v1
+- url: /api/v1
 components:
   securitySchemes:
     basic:
@@ -461,11 +461,11 @@ components:
   schemas:
     EnkelvoudigInformatieObject:
       required:
-        - creatiedatum
-        - titel
-        - auteur
-        - taal
-        - informatieobjecttype
+      - creatiedatum
+      - titel
+      - auteur
+      - taal
+      - informatieobjecttype
       type: object
       properties:
         url:
@@ -475,25 +475,21 @@ components:
           readOnly: true
         identificatie:
           title: Identificatie
-          description: >-
-            Een binnen een gegeven context ondubbelzinnige referentie naar het
-            INFORMATIEOBJECT.
+          description: Een binnen een gegeven context ondubbelzinnige referentie naar
+            het INFORMATIEOBJECT.
           type: string
           maxLength: 40
           minLength: 1
         bronorganisatie:
           title: Bronorganisatie
-          description: >-
-            Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die
-            het informatieobject heeft gecreëerd of heeft ontvangen en als
-            eerste in een samenwerkingsketen heeft vastgelegd.
+          description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie\
+            \ die het informatieobject heeft gecre\xEBerd of heeft ontvangen en als\
+            \ eerste in een samenwerkingsketen heeft vastgelegd."
           type: string
           maxLength: 9
         creatiedatum:
           title: Creatiedatum
-          description: >-
-            Een datum of een gebeurtenis in de levenscyclus van het
-            INFORMATIEOBJECT.
+          description: Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT.
           type: string
           format: date
         titel:
@@ -504,526 +500,522 @@ components:
           minLength: 1
         vertrouwelijkaanduiding:
           title: Vertrouwelijkaanduiding
-          description: >-
-            Aanduiding van de mate waarin het INFORMATIEOBJECT voor de
+          description: Aanduiding van de mate waarin het INFORMATIEOBJECT voor de
             openbaarheid bestemd is.
           type: string
           enum:
-            - openbaar
-            - beperkt openbaar
-            - intern
-            - zaakvertrouwelijk
-            - vertrouwelijk
-            - confidentieel
-            - geheim
-            - zeer geheim
+          - openbaar
+          - beperkt openbaar
+          - intern
+          - zaakvertrouwelijk
+          - vertrouwelijk
+          - confidentieel
+          - geheim
+          - zeer geheim
         auteur:
           title: Auteur
-          description: >-
-            De persoon of organisatie die in de eerste plaats verantwoordelijk
-            is voor het creëren van de inhoud van het INFORMATIEOBJECT.
+          description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
+            \ is voor het cre\xEBren van de inhoud van het INFORMATIEOBJECT."
           type: string
           maxLength: 200
           minLength: 1
         formaat:
           title: Formaat
-          description: >-
-            De code voor de wijze waarop de inhoud van het ENKELVOUDIG
+          description: De code voor de wijze waarop de inhoud van het ENKELVOUDIG
             INFORMATIEOBJECT is vastgelegd in een computerbestand.
           type: string
           maxLength: 255
         taal:
           title: Taal
-          description: >-
-            Een taal van de intellectuele inhoud van het ENKELVOUDIG
-            INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B
+          description: Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT.
+            De waardes komen uit ISO 639-2/B
           type: string
           enum:
-            - aar
-            - abk
-            - ace
-            - ach
-            - ada
-            - ady
-            - afh
-            - afr
-            - ain
-            - aka
-            - akk
-            - ale
-            - alt
-            - amh
-            - ang
-            - anp
-            - ara
-            - arc
-            - arg
-            - arn
-            - arp
-            - arw
-            - asm
-            - ast
-            - ava
-            - ave
-            - awa
-            - aym
-            - aze
-            - bak
-            - bal
-            - bam
-            - ban
-            - bas
-            - bej
-            - bel
-            - bem
-            - ben
-            - bho
-            - bik
-            - bin
-            - bis
-            - bla
-            - tib
-            - bos
-            - bra
-            - bre
-            - bua
-            - bug
-            - bul
-            - byn
-            - cad
-            - car
-            - cat
-            - ceb
-            - cze
-            - cha
-            - chb
-            - che
-            - chg
-            - chk
-            - chm
-            - chn
-            - cho
-            - chp
-            - chr
-            - chu
-            - chv
-            - chy
-            - cop
-            - cor
-            - cos
-            - cre
-            - crh
-            - csb
-            - wel
-            - dak
-            - dan
-            - dar
-            - del
-            - den
-            - ger
-            - dgr
-            - din
-            - div
-            - doi
-            - dsb
-            - dua
-            - dum
-            - dyu
-            - dzo
-            - efi
-            - egy
-            - eka
-            - gre
-            - elx
-            - eng
-            - enm
-            - epo
-            - est
-            - baq
-            - ewe
-            - ewo
-            - fan
-            - fao
-            - per
-            - fat
-            - fij
-            - fil
-            - fin
-            - fon
-            - fre
-            - frm
-            - fro
-            - frr
-            - frs
-            - fry
-            - ful
-            - fur
-            - gaa
-            - gay
-            - gba
-            - gez
-            - gil
-            - gla
-            - gle
-            - glg
-            - glv
-            - gmh
-            - goh
-            - gon
-            - gor
-            - got
-            - grb
-            - grc
-            - grn
-            - gsw
-            - guj
-            - gwi
-            - hai
-            - hat
-            - hau
-            - haw
-            - heb
-            - her
-            - hil
-            - hin
-            - hit
-            - hmn
-            - hmo
-            - hrv
-            - hsb
-            - hun
-            - hup
-            - arm
-            - iba
-            - ibo
-            - ido
-            - iii
-            - iku
-            - ile
-            - ilo
-            - ina
-            - ind
-            - inh
-            - ipk
-            - ice
-            - ita
-            - jav
-            - jbo
-            - jpn
-            - jpr
-            - jrb
-            - kaa
-            - kab
-            - kac
-            - kal
-            - kam
-            - kan
-            - kas
-            - geo
-            - kau
-            - kaw
-            - kaz
-            - kbd
-            - kha
-            - khm
-            - kho
-            - kik
-            - kin
-            - kir
-            - kmb
-            - kok
-            - kom
-            - kon
-            - kor
-            - kos
-            - kpe
-            - krc
-            - krl
-            - kru
-            - kua
-            - kum
-            - kur
-            - kut
-            - lad
-            - lah
-            - lam
-            - lao
-            - lat
-            - lav
-            - lez
-            - lim
-            - lin
-            - lit
-            - lol
-            - loz
-            - ltz
-            - lua
-            - lub
-            - lug
-            - lui
-            - lun
-            - luo
-            - lus
-            - mad
-            - mag
-            - mah
-            - mai
-            - mak
-            - mal
-            - man
-            - mar
-            - mas
-            - mdf
-            - mdr
-            - men
-            - mga
-            - mic
-            - min
-            - mis
-            - mac
-            - mlg
-            - mlt
-            - mnc
-            - mni
-            - moh
-            - mon
-            - mos
-            - mao
-            - may
-            - mul
-            - mus
-            - mwl
-            - mwr
-            - bur
-            - myv
-            - nap
-            - nau
-            - nav
-            - nbl
-            - nde
-            - ndo
-            - nds
-            - nep
-            - new
-            - nia
-            - niu
-            - dut
-            - nno
-            - nob
-            - nog
-            - non
-            - nor
-            - nqo
-            - nso
-            - nwc
-            - nya
-            - nym
-            - nyn
-            - nyo
-            - nzi
-            - oci
-            - oji
-            - ori
-            - orm
-            - osa
-            - oss
-            - ota
-            - pag
-            - pal
-            - pam
-            - pan
-            - pap
-            - pau
-            - peo
-            - phn
-            - pli
-            - pol
-            - pon
-            - por
-            - pro
-            - pus
-            - que
-            - raj
-            - rap
-            - rar
-            - roh
-            - rom
-            - rum
-            - run
-            - rup
-            - rus
-            - sad
-            - sag
-            - sah
-            - sam
-            - san
-            - sas
-            - sat
-            - scn
-            - sco
-            - sel
-            - sga
-            - shn
-            - sid
-            - sin
-            - slo
-            - slv
-            - sma
-            - sme
-            - smj
-            - smn
-            - smo
-            - sms
-            - sna
-            - snd
-            - snk
-            - sog
-            - som
-            - sot
-            - spa
-            - alb
-            - srd
-            - srn
-            - srp
-            - srr
-            - ssw
-            - suk
-            - sun
-            - sus
-            - sux
-            - swa
-            - swe
-            - syc
-            - syr
-            - tah
-            - tam
-            - tat
-            - tel
-            - tem
-            - ter
-            - tet
-            - tgk
-            - tgl
-            - tha
-            - tig
-            - tir
-            - tiv
-            - tkl
-            - tlh
-            - tli
-            - tmh
-            - tog
-            - ton
-            - tpi
-            - tsi
-            - tsn
-            - tso
-            - tuk
-            - tum
-            - tur
-            - tvl
-            - twi
-            - tyv
-            - udm
-            - uga
-            - uig
-            - ukr
-            - umb
-            - und
-            - urd
-            - uzb
-            - vai
-            - ven
-            - vie
-            - vol
-            - vot
-            - wal
-            - war
-            - was
-            - wln
-            - wol
-            - xal
-            - xho
-            - yao
-            - yap
-            - yid
-            - yor
-            - zap
-            - zbl
-            - zen
-            - zgh
-            - zha
-            - chi
-            - zul
-            - zun
-            - zxx
-            - zza
-            - afa
-            - alg
-            - apa
-            - art
-            - ath
-            - aus
-            - bad
-            - bai
-            - bat
-            - ber
-            - bih
-            - bnt
-            - btk
-            - cai
-            - cau
-            - cel
-            - cmc
-            - cpe
-            - cpf
-            - cpp
-            - crp
-            - cus
-            - day
-            - dra
-            - fiu
-            - gem
-            - ijo
-            - inc
-            - ine
-            - ira
-            - iro
-            - kar
-            - khi
-            - kro
-            - map
-            - mkh
-            - mno
-            - mun
-            - myn
-            - nah
-            - nai
-            - nic
-            - nub
-            - oto
-            - paa
-            - phi
-            - pra
-            - roa
-            - sai
-            - sal
-            - sem
-            - sgn
-            - sio
-            - sit
-            - sla
-            - smi
-            - son
-            - ssa
-            - tai
-            - tup
-            - tut
-            - wak
-            - wen
-            - ypk
-            - znd
-            - him
+          - aar
+          - abk
+          - ace
+          - ach
+          - ada
+          - ady
+          - afh
+          - afr
+          - ain
+          - aka
+          - akk
+          - ale
+          - alt
+          - amh
+          - ang
+          - anp
+          - ara
+          - arc
+          - arg
+          - arn
+          - arp
+          - arw
+          - asm
+          - ast
+          - ava
+          - ave
+          - awa
+          - aym
+          - aze
+          - bak
+          - bal
+          - bam
+          - ban
+          - bas
+          - bej
+          - bel
+          - bem
+          - ben
+          - bho
+          - bik
+          - bin
+          - bis
+          - bla
+          - tib
+          - bos
+          - bra
+          - bre
+          - bua
+          - bug
+          - bul
+          - byn
+          - cad
+          - car
+          - cat
+          - ceb
+          - cze
+          - cha
+          - chb
+          - che
+          - chg
+          - chk
+          - chm
+          - chn
+          - cho
+          - chp
+          - chr
+          - chu
+          - chv
+          - chy
+          - cop
+          - cor
+          - cos
+          - cre
+          - crh
+          - csb
+          - wel
+          - dak
+          - dan
+          - dar
+          - del
+          - den
+          - ger
+          - dgr
+          - din
+          - div
+          - doi
+          - dsb
+          - dua
+          - dum
+          - dyu
+          - dzo
+          - efi
+          - egy
+          - eka
+          - gre
+          - elx
+          - eng
+          - enm
+          - epo
+          - est
+          - baq
+          - ewe
+          - ewo
+          - fan
+          - fao
+          - per
+          - fat
+          - fij
+          - fil
+          - fin
+          - fon
+          - fre
+          - frm
+          - fro
+          - frr
+          - frs
+          - fry
+          - ful
+          - fur
+          - gaa
+          - gay
+          - gba
+          - gez
+          - gil
+          - gla
+          - gle
+          - glg
+          - glv
+          - gmh
+          - goh
+          - gon
+          - gor
+          - got
+          - grb
+          - grc
+          - grn
+          - gsw
+          - guj
+          - gwi
+          - hai
+          - hat
+          - hau
+          - haw
+          - heb
+          - her
+          - hil
+          - hin
+          - hit
+          - hmn
+          - hmo
+          - hrv
+          - hsb
+          - hun
+          - hup
+          - arm
+          - iba
+          - ibo
+          - ido
+          - iii
+          - iku
+          - ile
+          - ilo
+          - ina
+          - ind
+          - inh
+          - ipk
+          - ice
+          - ita
+          - jav
+          - jbo
+          - jpn
+          - jpr
+          - jrb
+          - kaa
+          - kab
+          - kac
+          - kal
+          - kam
+          - kan
+          - kas
+          - geo
+          - kau
+          - kaw
+          - kaz
+          - kbd
+          - kha
+          - khm
+          - kho
+          - kik
+          - kin
+          - kir
+          - kmb
+          - kok
+          - kom
+          - kon
+          - kor
+          - kos
+          - kpe
+          - krc
+          - krl
+          - kru
+          - kua
+          - kum
+          - kur
+          - kut
+          - lad
+          - lah
+          - lam
+          - lao
+          - lat
+          - lav
+          - lez
+          - lim
+          - lin
+          - lit
+          - lol
+          - loz
+          - ltz
+          - lua
+          - lub
+          - lug
+          - lui
+          - lun
+          - luo
+          - lus
+          - mad
+          - mag
+          - mah
+          - mai
+          - mak
+          - mal
+          - man
+          - mar
+          - mas
+          - mdf
+          - mdr
+          - men
+          - mga
+          - mic
+          - min
+          - mis
+          - mac
+          - mlg
+          - mlt
+          - mnc
+          - mni
+          - moh
+          - mon
+          - mos
+          - mao
+          - may
+          - mul
+          - mus
+          - mwl
+          - mwr
+          - bur
+          - myv
+          - nap
+          - nau
+          - nav
+          - nbl
+          - nde
+          - ndo
+          - nds
+          - nep
+          - new
+          - nia
+          - niu
+          - dut
+          - nno
+          - nob
+          - nog
+          - non
+          - nor
+          - nqo
+          - nso
+          - nwc
+          - nya
+          - nym
+          - nyn
+          - nyo
+          - nzi
+          - oci
+          - oji
+          - ori
+          - orm
+          - osa
+          - oss
+          - ota
+          - pag
+          - pal
+          - pam
+          - pan
+          - pap
+          - pau
+          - peo
+          - phn
+          - pli
+          - pol
+          - pon
+          - por
+          - pro
+          - pus
+          - que
+          - raj
+          - rap
+          - rar
+          - roh
+          - rom
+          - rum
+          - run
+          - rup
+          - rus
+          - sad
+          - sag
+          - sah
+          - sam
+          - san
+          - sas
+          - sat
+          - scn
+          - sco
+          - sel
+          - sga
+          - shn
+          - sid
+          - sin
+          - slo
+          - slv
+          - sma
+          - sme
+          - smj
+          - smn
+          - smo
+          - sms
+          - sna
+          - snd
+          - snk
+          - sog
+          - som
+          - sot
+          - spa
+          - alb
+          - srd
+          - srn
+          - srp
+          - srr
+          - ssw
+          - suk
+          - sun
+          - sus
+          - sux
+          - swa
+          - swe
+          - syc
+          - syr
+          - tah
+          - tam
+          - tat
+          - tel
+          - tem
+          - ter
+          - tet
+          - tgk
+          - tgl
+          - tha
+          - tig
+          - tir
+          - tiv
+          - tkl
+          - tlh
+          - tli
+          - tmh
+          - tog
+          - ton
+          - tpi
+          - tsi
+          - tsn
+          - tso
+          - tuk
+          - tum
+          - tur
+          - tvl
+          - twi
+          - tyv
+          - udm
+          - uga
+          - uig
+          - ukr
+          - umb
+          - und
+          - urd
+          - uzb
+          - vai
+          - ven
+          - vie
+          - vol
+          - vot
+          - wal
+          - war
+          - was
+          - wln
+          - wol
+          - xal
+          - xho
+          - yao
+          - yap
+          - yid
+          - yor
+          - zap
+          - zbl
+          - zen
+          - zgh
+          - zha
+          - chi
+          - zul
+          - zun
+          - zxx
+          - zza
+          - afa
+          - alg
+          - apa
+          - art
+          - ath
+          - aus
+          - bad
+          - bai
+          - bat
+          - ber
+          - bih
+          - bnt
+          - btk
+          - cai
+          - cau
+          - cel
+          - cmc
+          - cpe
+          - cpf
+          - cpp
+          - crp
+          - cus
+          - day
+          - dra
+          - fiu
+          - gem
+          - ijo
+          - inc
+          - ine
+          - ira
+          - iro
+          - kar
+          - khi
+          - kro
+          - map
+          - mkh
+          - mno
+          - mun
+          - myn
+          - nah
+          - nai
+          - nic
+          - nub
+          - oto
+          - paa
+          - phi
+          - pra
+          - roa
+          - sai
+          - sal
+          - sem
+          - sgn
+          - sio
+          - sit
+          - sla
+          - smi
+          - son
+          - ssa
+          - tai
+          - tup
+          - tut
+          - wak
+          - wen
+          - ypk
+          - znd
+          - him
         inhoud:
           title: Inhoud
           type: string
@@ -1031,7 +1023,8 @@ components:
           format: uri
         link:
           title: Link
-          description: De URL waarmee de inhoud van het INFORMATIEOBJECT op te vragen is.
+          description: De URL waarmee de inhoud van het INFORMATIEOBJECT op te vragen
+            is.
           type: string
           format: uri
           maxLength: 200
@@ -1049,16 +1042,16 @@ components:
           minLength: 1
     Fout:
       required:
-        - code
-        - title
-        - status
-        - detail
-        - instance
+      - code
+      - title
+      - status
+      - detail
+      - instance
       type: object
       properties:
         type:
           title: Type
-          description: 'URI referentie naar het type fout, bedoeld voor developers'
+          description: URI referentie naar het type fout, bedoeld voor developers
           type: string
         code:
           title: Code
@@ -1076,21 +1069,20 @@ components:
           type: integer
         detail:
           title: Detail
-          description: 'Extra informatie bij de fout, indien beschikbaar'
+          description: Extra informatie bij de fout, indien beschikbaar
           type: string
           minLength: 1
         instance:
           title: Instance
-          description: >-
-            URI met referentie naar dit specifiek voorkomen van de fout. Deze
-            kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          description: URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
     FieldValidationError:
       required:
-        - name
-        - code
-        - reason
+      - name
+      - code
+      - reason
       type: object
       properties:
         name:
@@ -1110,17 +1102,17 @@ components:
           minLength: 1
     ValidatieFout:
       required:
-        - code
-        - title
-        - status
-        - detail
-        - instance
-        - invalid-params
+      - code
+      - title
+      - status
+      - detail
+      - instance
+      - invalid-params
       type: object
       properties:
         type:
           title: Type
-          description: 'URI referentie naar het type fout, bedoeld voor developers'
+          description: URI referentie naar het type fout, bedoeld voor developers
           type: string
         code:
           title: Code
@@ -1138,14 +1130,13 @@ components:
           type: integer
         detail:
           title: Detail
-          description: 'Extra informatie bij de fout, indien beschikbaar'
+          description: Extra informatie bij de fout, indien beschikbaar
           type: string
           minLength: 1
         instance:
           title: Instance
-          description: >-
-            URI met referentie naar dit specifiek voorkomen van de fout. Deze
-            kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
+          description: URI met referentie naar dit specifiek voorkomen van de fout.
+            Deze kan gebruikt worden in combinatie met server logs, bijvoorbeeld.
           type: string
           minLength: 1
         invalid-params:
@@ -1154,8 +1145,8 @@ components:
             $ref: '#/components/schemas/FieldValidationError'
     ZaakInformatieObject:
       required:
-        - zaak
-        - informatieobject
+      - zaak
+      - informatieobject
       type: object
       properties:
         url:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -27,49 +27,49 @@ paths:
         '401':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
@@ -90,55 +90,55 @@ paths:
         '400':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
@@ -164,55 +164,55 @@ paths:
         '401':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
@@ -256,49 +256,49 @@ paths:
         '401':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
@@ -316,55 +316,55 @@ paths:
         '400':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:
@@ -390,55 +390,55 @@ paths:
         '401':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
           description: ''
           content:
-            application/error+json:
+            application/problem+json:
               schema:
                 $ref: '#/components/schemas/Fout'
       tags:

--- a/src/resources.md
+++ b/src/resources.md
@@ -1,0 +1,38 @@
+# Resources
+
+Dit document beschrijft de (RGBZ-)objecttypen die als resources ontsloten
+worden met de beschikbare attributen.
+
+
+## EnkelvoudigInformatieObject
+
+Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/objecttype/enkelvoudiginformatieobject)
+
+| Attribuut | Omschrijving | Type | Verplicht | CRUD* |
+| --- | --- | --- | --- | --- |
+| url |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| identificatie | Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. | string | nee | C​R​U​D |
+| bronorganisatie | Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. | string | nee | C​R​U​D |
+| creatiedatum | Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. | string | ja | C​R​U​D |
+| titel | De naam waaronder het INFORMATIEOBJECT formeel bekend is. | string | ja | C​R​U​D |
+| vertrouwelijkaanduiding | Aanduiding van de mate waarin het INFORMATIEOBJECT voor de openbaarheid bestemd is. | string | nee | C​R​U​D |
+| auteur | De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. | string | ja | C​R​U​D |
+| formaat | De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand. | string | nee | C​R​U​D |
+| taal | Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B | string | ja | C​R​U​D |
+| inhoud |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| link | De URL waarmee de inhoud van het INFORMATIEOBJECT op te vragen is. | string | nee | C​R​U​D |
+| beschrijving | Een generieke beschrijving van de inhoud van het INFORMATIEOBJECT. | string | nee | C​R​U​D |
+| informatieobjecttype | URL naar de INFORMATIEOBJECTTYPE in het ZTC. | string | ja | C​R​U​D |
+
+## ZaakInformatieObject
+
+Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/objecttype/zaakinformatieobject)
+
+| Attribuut | Omschrijving | Type | Verplicht | CRUD* |
+| --- | --- | --- | --- | --- |
+| url |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| zaak | URL naar de ZAAK in het ZRC. | string | ja | C​R​U​D |
+| informatieobject |  | string | ja | C​R​U​D |
+
+
+* Create, Read, Update, Delete


### PR DESCRIPTION
`application/json` is geworden `application/error+json` voor HTTP 4xx en HTTP 5xx.

Afwijkingen in `openapi.yaml` zijn deels cosmetisch en komen door de gebruikte `oaml` library omdat `pyyaml` de volgorde niet deterministisch uitspuugt. Wordt over alle referentie-implementaties rechtgetrokken.

TODO:
- [x] tests