### PR TITLE
Authenticate against ZTC and ZRC

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,4 +18,4 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
-zds-schema==0.10.7
+zds-schema==0.11.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,6 +6,8 @@ python-dateutil
 pytz
 raven
 
+gemma-zds-client>=0.6.0
+
 Django
 django-axes
 django-choices

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ python-dateutil
 pytz
 raven
 
-gemma-zds-client>=0.6.0
+gemma-zds-client>=0.6.1
 
 Django
 django-axes

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,4 +18,4 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
-zds-schema==0.11.0
+zds-schema==0.12.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,4 +18,4 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
-zds-schema==0.8.0
+zds-schema==0.10.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,7 +36,7 @@ oyaml==0.7                # via zds-schema
 pillow==5.2.0
 pip-tools==2.0.2
 psycopg2-binary==2.7.5
-pyjwt==1.6.4              # via gemma-zds-client
+pyjwt==1.6.4              # via gemma-zds-client, zds-schema
 python-dateutil==2.7.3
 python-dotenv==0.8.2
 pytz==2018.4
@@ -48,4 +48,4 @@ six==1.11.0               # via drf-yasg, isodate, pip-tools, python-dateutil
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23             # via requests
-zds-schema==0.8.0
+zds-schema==0.10.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,4 +48,4 @@ six==1.11.0               # via drf-yasg, isodate, pip-tools, python-dateutil
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23             # via requests
-zds-schema==0.11.0
+zds-schema==0.12.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ drf-nested-routers==0.90.2  # via zds-schema
 drf-yasg==1.9.0
 first==2.0.1              # via pip-tools
 future==0.16.0            # via drf-yasg
-gemma-zds-client==0.6.0
+gemma-zds-client==0.6.1
 idna==2.7                 # via requests
 inflection==0.3.1         # via drf-yasg
 iso-639==0.4.5            # via zds-schema

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ drf-nested-routers==0.90.2  # via zds-schema
 drf-yasg==1.9.0
 first==2.0.1              # via pip-tools
 future==0.16.0            # via drf-yasg
-gemma-zds-client==0.4.3   # via zds-schema
+gemma-zds-client==0.6.0
 idna==2.7                 # via requests
 inflection==0.3.1         # via drf-yasg
 iso-639==0.4.5            # via zds-schema
@@ -36,6 +36,7 @@ oyaml==0.7                # via zds-schema
 pillow==5.2.0
 pip-tools==2.0.2
 psycopg2-binary==2.7.5
+pyjwt==1.6.4              # via gemma-zds-client
 python-dateutil==2.7.3
 python-dotenv==0.8.2
 pytz==2018.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,4 +48,4 @@ six==1.11.0               # via drf-yasg, isodate, pip-tools, python-dateutil
 unidecode==1.0.22         # via zds-schema
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.23             # via requests
-zds-schema==0.10.7
+zds-schema==0.11.0

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -32,7 +32,7 @@ faker==0.8.17             # via factory-boy
 first==2.0.1
 freezegun==0.3.10
 future==0.16.0
-gemma-zds-client==0.4.3
+gemma-zds-client==0.6.0
 idna==2.7
 inflection==0.3.1
 iso-639==0.4.5
@@ -52,6 +52,7 @@ pep8==1.7.1
 pillow==5.2.0
 pip-tools==2.0.2
 psycopg2-binary==2.7.5
+pyjwt==1.6.4
 pylint==1.9.2
 pyquery==1.4.0
 python-dateutil==2.7.3

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -72,4 +72,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.8.0
+zds-schema==0.10.7

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -72,4 +72,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.10.7
+zds-schema==0.11.0

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -72,4 +72,4 @@ waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30
 wrapt==1.10.11            # via astroid
-zds-schema==0.11.0
+zds-schema==0.12.0

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -32,7 +32,7 @@ faker==0.8.17             # via factory-boy
 first==2.0.1
 freezegun==0.3.10
 future==0.16.0
-gemma-zds-client==0.6.0
+gemma-zds-client==0.6.1
 idna==2.7
 inflection==0.3.1
 iso-639==0.4.5

--- a/src/drc/api/auth.py
+++ b/src/drc/api/auth.py
@@ -1,16 +1,27 @@
-from django.conf import settings
+import logging
 
-from zds_client import ClientAuth
+from zds_schema.models import APICredential
 
-ztc_auth = ClientAuth(
-    client_id=settings.ZTC_JWT_CLIENT_ID,
-    secret=settings.ZTC_JWT_SECRET,
-    scopes=['zds.scopes.zaaktypes.lezen']
-)
+logger = logging.getLogger(__name__)
 
-zrc_auth = ClientAuth(
-    client_id=settings.ZRC_JWT_CLIENT_ID,
-    secret=settings.ZRC_JWT_SECRET,
-    scopes=['zds.scopes.zaken.lezen'],
-    zaaktypes=['*']
-)
+
+def get_ztc_auth(url: str) -> dict:
+    logger.info("Authenticating for %s", url)
+    auth = APICredential.get_auth(url, scopes=['zds.scopes.zaaktypes.lezen'])
+    if auth is None:
+        logger.warning("Could not authenticate for %s", url)
+        return {}
+    return auth.credentials()
+
+
+def get_zrc_auth(url: str) -> dict:
+    logger.info("Authenticating for %s", url)
+    auth = APICredential.get_auth(
+        url,
+        scopes=['zds.scopes.zaken.lezen'],
+        zaaktypes=['*']
+    )
+    if auth is None:
+        logger.warning("Could not authenticate for %s", url)
+        return {}
+    return auth.credentials()

--- a/src/drc/api/auth.py
+++ b/src/drc/api/auth.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+
+from zds_client import ClientAuth
+
+ztc_auth = ClientAuth(
+    client_id=settings.ZTC_JWT_CLIENT_ID,
+    secret=settings.ZTC_JWT_SECRET,
+    scopes=['zds.scopes.zaaktypes.lezen']
+)
+
+zrc_auth = ClientAuth(
+    client_id=settings.ZRC_JWT_CLIENT_ID,
+    secret=settings.ZRC_JWT_SECRET,
+    scopes=['zds.scopes.zaken.lezen'],
+    zaaktypes=['*']
+)

--- a/src/drc/api/serializers.py
+++ b/src/drc/api/serializers.py
@@ -13,7 +13,7 @@ from drc.datamodel.models import (
     EnkelvoudigInformatieObject, ObjectInformatieObject
 )
 
-from .auth import zrc_auth, ztc_auth
+from .auth import get_zrc_auth, get_ztc_auth
 
 
 class AnyFileType:
@@ -57,16 +57,9 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
                 'lookup_field': 'uuid',
             },
             'informatieobjecttype': {
-                'validators': [URLValidator(headers=ztc_auth.credentials)],
+                'validators': [URLValidator(get_auth=get_ztc_auth)],
             }
         }
-
-
-def get_zrc_headers() -> dict:
-    headers = {}
-    headers.update(zrc_auth.credentials())
-    headers.update({'Accept-Crs': 'EPSG:4326'})
-    return headers
 
 
 class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
@@ -99,7 +92,7 @@ class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
             },
             'object': {
                 'validators': [
-                    URLValidator(headers=get_zrc_headers),
+                    URLValidator(get_auth=get_zrc_auth, headers={'Accept-Crs': 'EPSG:4326'}),
                     IsImmutableValidator(),
                 ],
             },

--- a/src/drc/api/serializers.py
+++ b/src/drc/api/serializers.py
@@ -13,6 +13,8 @@ from drc.datamodel.models import (
     EnkelvoudigInformatieObject, ObjectInformatieObject
 )
 
+from .auth import zrc_auth, ztc_auth
+
 
 class AnyFileType:
     def __contains__(self, item):
@@ -55,9 +57,16 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
                 'lookup_field': 'uuid',
             },
             'informatieobjecttype': {
-                'validators': [URLValidator()],
+                'validators': [URLValidator(headers=ztc_auth.credentials)],
             }
         }
+
+
+def get_zrc_headers() -> dict:
+    headers = {}
+    headers.update(zrc_auth.credentials())
+    headers.update({'Accept-Crs': 'EPSG:4326'})
+    return headers
 
 
 class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
@@ -90,7 +99,7 @@ class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
             },
             'object': {
                 'validators': [
-                    URLValidator(headers={'Accept-Crs': 'EPSG:4326'}),
+                    URLValidator(headers=get_zrc_headers),
                     IsImmutableValidator(),
                 ],
             },

--- a/src/drc/api/urls.py
+++ b/src/drc/api/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
+from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
@@ -26,5 +27,8 @@ urlpatterns = [
 
         # actual API
         url(r'^', include(router.urls)),
+
+        # should not be picked up by drf-yasg
+        path('', include('zds_schema.api.urls')),
     ])),
 ]

--- a/src/drc/conf/api.py
+++ b/src/drc/conf/api.py
@@ -1,3 +1,5 @@
+import os
+
 from zds_schema.conf.api import *  # noqa - imports white-listed
 
 REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
@@ -13,3 +15,9 @@ SWAGGER_SETTINGS.update({
 })
 
 GEMMA_URL_INFORMATIEMODEL_VERSIE = '1.0'
+
+ZTC_JWT_CLIENT_ID = 'drc'
+ZTC_JWT_SECRET = os.getenv('ZTC_JWT_SECRET')
+
+ZRC_JWT_CLIENT_ID = 'drc'
+ZRC_JWT_SECRET = os.getenv('ZRC_JWT_SECRET')

--- a/src/drc/conf/api.py
+++ b/src/drc/conf/api.py
@@ -1,5 +1,3 @@
-import os
-
 from zds_schema.conf.api import *  # noqa - imports white-listed
 
 REST_FRAMEWORK = BASE_REST_FRAMEWORK.copy()
@@ -15,9 +13,3 @@ SWAGGER_SETTINGS.update({
 })
 
 GEMMA_URL_INFORMATIEMODEL_VERSIE = '1.0'
-
-ZTC_JWT_CLIENT_ID = 'drc'
-ZTC_JWT_SECRET = os.getenv('ZTC_JWT_SECRET')
-
-ZRC_JWT_CLIENT_ID = 'drc'
-ZRC_JWT_SECRET = os.getenv('ZRC_JWT_SECRET')

--- a/src/drc/conf/dev.py
+++ b/src/drc/conf/dev.py
@@ -5,6 +5,9 @@ os.environ.setdefault('DB_NAME', 'drc')
 os.environ.setdefault('DB_USER', 'drc')
 os.environ.setdefault('DB_PASSWORD', 'drc')
 
+os.environ.setdefault('ZTC_JWT_SECRET', 'drc-to-ztc')
+os.environ.setdefault('ZRC_JWT_SECRET', 'drc-to-zrc')
+
 from .base import *  # noqa isort:skip
 
 #


### PR DESCRIPTION
ZRC & ZTC vereisen dat de juiste scopes gebruikt worden op hun
endpoints. Ook bij systeem-naar-systeem calls moet dit gebeuren. De
validators op de serializers kunnen nu credentials meegeven, steunend
op gemma-zds-client  mechanismes.