### PR TITLE
Changed dash to underscore for invalid_params in DSO api strategy tests

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -21,4 +21,4 @@ django-filter
 djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
-vng-api-common[notifications]==0.38.0
+vng-api-common==0.46.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,4 +63,4 @@ sphinxcontrib-websupport==1.1.0  # via sphinx
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.1           # via requests
-vng-api-common[notifications]==0.38.0
+vng-api-common==0.46.2

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -81,7 +81,7 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.1
-vng-api-common[notifications]==0.38.0
+vng-api-common==0.46.2
 waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30

--- a/src/drc/api/tests/test_dso_api_strategy.py
+++ b/src/drc/api/tests/test_dso_api_strategy.py
@@ -64,7 +64,7 @@ class DSOApi50Tests(APITestCase):
                 'title': 'Invalid input.',
                 'status': 400,
                 'detail': '',
-                'invalid-params': [{
+                'invalid_params': [{
                     'name': 'foo',
                     'code': 'validation-error',
                     'reason': 'Invalid data.',

--- a/src/drc/conf/base.py
+++ b/src/drc/conf/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'django_filters',
     'corsheaders',
     'vng_api_common',  # before drf_yasg to override the management command
+    'vng_api_common.authorizations',
     'vng_api_common.notifications',
     'drf_yasg',
     'rest_framework',


### PR DESCRIPTION
Due to changes to vng-api-common in [this commit](https://github.com/VNG-Realisatie/vng-api-common/commit/ebaf211b2d6501598e709e287b3ce803997ee0c7), `invalid-params` had to be changed to `invalid_params` in DSO API strategy tests