### PR TITLE
Feature/oas consistency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -64,4 +64,4 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.22         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-vng-api-common==0.57.3
+vng-api-common==0.58.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ djangorestframework-filters==0.10.2
 djangorestframework==3.9.4
 docutils==0.14            # via sphinx
 drf-nested-routers==0.90.2  # via vng-api-common
-drf-yasg==1.15.0
+drf-yasg==1.16.0
 first==2.0.1              # via pip-tools
 gemma-zds-client==0.11.0  # via vng-api-common
 idna==2.7                 # via requests

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -11,6 +11,7 @@ beautifulsoup4==4.6.0     # via webtest
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
+colorama==0.4.1
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.1
@@ -82,7 +83,7 @@ text-unidecode==1.2       # via faker
 unidecode==1.0.22
 uritemplate==3.0.0
 urllib3==1.24.3
-vng-api-common==0.57.3
+vng-api-common==0.58.1
 waitress==1.1.0           # via webtest
 webob==1.8.2              # via webtest
 webtest==2.0.30

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -34,7 +34,7 @@ djangorestframework-filters==0.10.2
 djangorestframework==3.9.4
 docutils==0.14
 drf-nested-routers==0.90.2
-drf-yasg==1.15.0
+drf-yasg==1.16.0
 factory-boy==2.11.1
 faker==0.8.17             # via factory-boy
 first==2.0.1

--- a/src/drc/api/filters.py
+++ b/src/drc/api/filters.py
@@ -1,6 +1,7 @@
 from django_filters import rest_framework as filters
 from vng_api_common.filters import URLModelChoiceFilter
 from vng_api_common.filtersets import FilterSet
+from vng_api_common.utils import get_help_text
 
 from drc.datamodel.models import (
     EnkelvoudigInformatieObject, EnkelvoudigInformatieObjectCanonical,
@@ -29,7 +30,8 @@ class EnkelvoudigInformatieObjectDetailFilter(FilterSet):
 class ObjectInformatieObjectFilter(FilterSet):
     informatieobject = URLModelChoiceFilter(
         queryset=EnkelvoudigInformatieObjectCanonical.objects.all(),
-        instance_path='canonical'
+        instance_path='canonical',
+        help_text=get_help_text('datamodel.ObjectInformatieObject', 'informatieobject'),
     )
 
     class Meta:
@@ -43,7 +45,8 @@ class ObjectInformatieObjectFilter(FilterSet):
 class GebruiksrechtenFilter(FilterSet):
     informatieobject = URLModelChoiceFilter(
         queryset=EnkelvoudigInformatieObjectCanonical.objects.all(),
-        instance_path='canonical'
+        instance_path='canonical',
+        help_text=get_help_text('datamodel.Gebruiksrechten', 'informatieobject'),
     )
 
     class Meta:

--- a/src/drc/api/schema.py
+++ b/src/drc/api/schema.py
@@ -2,37 +2,54 @@ from django.conf import settings
 
 from drf_yasg import openapi
 
-description = """Een API om een documentregistratiecomponent te benaderen.
+from .kanalen import KANAAL_DOCUMENTEN
 
-Een informatieobject is een digitaal document voorzien van meta-gegevens.
-Informatieobjecten kunnen aan andere objecten zoals zaken en besluiten worden
-gerelateerd (maar dat hoeft niet) en kunnen gebruiksrechten hebben.
-Gebruiksrechten leggen voorwaarden op aan het gebruik van het informatieobject
-(buiten raadpleging). Deze gebruiksrechten worden niet door de API gevalideerd
+description = f"""Een API om een documentregistratiecomponent (DRC) te benaderen.
+
+In een documentregistratiecomponent worden INFORMATIEOBJECTen opgeslagen. Een 
+INFORMATIEOBJECT is een digitaal document voorzien van meta-gegevens. 
+INFORMATIEOBJECTen kunnen aan andere objecten zoals zaken en besluiten worden 
+gerelateerd (maar dat hoeft niet) en kunnen gebruiksrechten hebben. 
+
+GEBRUIKSRECHTEN leggen voorwaarden op aan het gebruik van het INFORMATIEOBJECT
+(buiten raadpleging). Deze GEBRUIKSRECHTEN worden niet door de API gevalideerd
 of gehandhaafd.
 
-De typering van informatieobjecten is in de zaaktypecatalogus (ZTC)
-ondergebracht in de vorm van informatieobjecttypen.
+De typering van INFORMATIEOBJECTen is in de Catalogi API (ZTC) ondergebracht in
+de vorm van INFORMATIEOBJECTTYPEn.
+
+**Afhankelijkheden**
+
+Deze API is afhankelijk van:
+
+* Catalogi API
+* Notificaties API
+* Autorisaties API *(optioneel)*
+* Zaken API *(optioneel)*
 
 **Autorisatie**
 
-Deze API vereist nog geen autorisatie. Je mag wel JWT-tokens gegenereerd door
-de [token-tool](https://ref.tst.vng.cloud/tokens/) gebruiken - deze worden
-voor nu genegeerd.
+Deze API vereist autorisatie. Je kan de
+[token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens te
+genereren.
+
+**Notificaties**
+
+Deze API publiceert notificaties op het kanaal `{KANAAL_DOCUMENTEN.label}`.
 
 **Handige links**
 
-* [Aan de slag](https://ref.tst.vng.cloud/ontwikkelaars/)
-* ["Papieren" standaard](https://ref.tst.vng.cloud/standaard/)
+* [Documentatie](https://zaakgerichtwerken.vng.cloud/standaard)
+* [Zaakgericht werken](https://zaakgerichtwerken.vng.cloud)
 """
 
 info = openapi.Info(
-    title="Documentregistratiecomponent (drc) API",
+    title=f"{settings.PROJECT_NAME} API",
     default_version=settings.API_VERSION,
     description=description,
     contact=openapi.Contact(
-        email="support@maykinmedia.nl",
-        url="https://github.com/VNG-Realisatie/gemma-zaken"
+        email="standaarden.ondersteuning@vng.nl",
+        url="https://zaakgerichtwerken.vng.cloud"
     ),
     license=openapi.License(
         name="EUPL 1.2",

--- a/src/drc/api/serializers.py
+++ b/src/drc/api/serializers.py
@@ -15,6 +15,7 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 from vng_api_common.models import APICredential
 from vng_api_common.serializers import GegevensGroepSerializer
+from vng_api_common.utils import get_help_text
 from vng_api_common.validators import IsImmutableValidator, URLValidator
 
 from drc.datamodel.models import (
@@ -120,8 +121,8 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
     )
     inhoud = AnyBase64File(view_name='enkelvoudiginformatieobject-download')
     bestandsomvang = serializers.IntegerField(
-        source='inhoud.size', read_only=True,
-        min_value=0
+        source='inhoud.size', read_only=True, min_value=0,
+        help_text=_("Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.")
     )
     integriteit = IntegriteitSerializer(
         label=_("integriteit"), allow_null=True, required=False,
@@ -360,6 +361,7 @@ class ObjectInformatieObjectSerializer(serializers.HyperlinkedModelSerializer):
         view_name='enkelvoudiginformatieobject-detail',
         lookup_field='uuid',
         queryset=EnkelvoudigInformatieObject.objects,
+        help_text=get_help_text('datamodel.ObjectInformatieObject', 'informatieobject'),
     )
 
     class Meta:
@@ -401,6 +403,7 @@ class GebruiksrechtenSerializer(serializers.HyperlinkedModelSerializer):
         view_name='enkelvoudiginformatieobject-detail',
         lookup_field='uuid',
         queryset=EnkelvoudigInformatieObject.objects,
+        help_text=get_help_text('datamodel.Gebruiksrechten', 'informatieobject'),
     )
 
     class Meta:

--- a/src/drc/api/viewsets.py
+++ b/src/drc/api/viewsets.py
@@ -75,57 +75,79 @@ class EnkelvoudigInformatieObjectViewSet(NotificationViewSetMixin,
                                          AuditTrailViewsetMixin,
                                          viewsets.ModelViewSet):
     """
-    Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.
+    Opvragen en bewerken van (ENKELVOUDIG) INFORMATIEOBJECTen (documenten).
 
     create:
-    Registreer een ENKELVOUDIG INFORMATIEOBJECT.
+    Maak een (ENKELVOUDIG) INFORMATIEOBJECT aan.
 
     **Er wordt gevalideerd op**
-    - geldigheid informatieobjecttype URL
+    - geldigheid `informatieobjecttype` URL
 
     list:
-    Geef een lijst van de laatste versies van ENKELVOUDIGe INFORMATIEOBJECTen
-    (=documenten).
+    Alle (ENKELVOUDIGe) INFORMATIEOBJECTen opvragen.
 
+    Deze lijst kan gefilterd wordt met query-string parameters.
 
-    De objecten bevatten metadata over de documenten en de downloadlink naar
-    de binary data.
+    De objecten bevatten metadata over de documenten en de downloadlink
+    (`inhoud`) naar de binary data.
 
     retrieve:
-    Geef de details van de laatste versie ENKELVOUDIG INFORMATIEOBJECT.
+    Een specifiek (ENKELVOUDIGe) INFORMATIEOBJECT opvragen.
 
-    Het object bevat metadata over het informatieobject en de downloadlink naar
-    de binary data.
+    Een specifiek (ENKELVOUDIGe) INFORMATIEOBJECT opvragen.
 
-    Er kan gefiltered worden met querystringparameters.
+    Het object bevat metadata over het document en de downloadlink (`inhoud`)
+    naar de binary data.
 
     update:
-    Maak een nieuwe versie van een ENKELVOUDIG INFORMATIEOBJECT aan door de
-    volledige resource mee te sturen.
+    Werk een (ENKELVOUDIG) INFORMATIEOBJECT in zijn geheel bij.
 
     **Er wordt gevalideerd op**
-    - geldigheid informatieobjecttype URL
+    - correcte `lock` waarde
+    - geldigheid `informatieobjecttype` URL
 
     *TODO*
     - valideer immutable attributes
 
     partial_update:
-    Maak een nieuwe versie van een ENKELVOUDIG INFORMATIEOBJECT aan door enkel
-    de gewijzigde velden mee te sturen.
+    Werk een (ENKELVOUDIG) INFORMATIEOBJECT deels bij.
 
     **Er wordt gevalideerd op**
-    - geldigheid informatieobjecttype URL
+    - correcte `lock` waarde
+    - geldigheid `informatieobjecttype` URL
 
     *TODO*
     - valideer immutable attributes
 
     destroy:
-    Verwijdert een ENKELVOUDIG INFORMATIEOBJECT en alle bijbehorende versies,
+    Verwijder een (ENKELVOUDIG) INFORMATIEOBJECT.
+
+    Verwijder een (ENKELVOUDIG) INFORMATIEOBJECT en alle bijbehorende versies,
     samen met alle gerelateerde resources binnen deze API.
 
     **Gerelateerde resources**
-    - `ObjectInformatieObject` - alle relaties van het informatieobject
-    - `Gebruiksrechten` - alle gebruiksrechten van het informatieobject
+    - OBJECT-INFORMATIEOBJECT
+    - GEBRUIKSRECHTen
+    - audit trail regels
+
+    download:
+    Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT.
+
+    Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT.
+
+    lock:
+    Vergrendel een (ENKELVOUDIG) INFORMATIEOBJECT.
+
+    Voert een "checkout" uit waardoor het (ENKELVOUDIG) INFORMATIEOBJECT
+    vergrendeld wordt met een `lock` waarde. Alleen met deze waarde kan het
+    (ENKELVOUDIG) INFORMATIEOBJECT bijgewerkt (`PUT`, `PATCH`) en weer
+    ontgrendeld worden.
+
+    unlock:
+    Ontgrendel een (ENKELVOUDIG) INFORMATIEOBJECT.
+
+    Heft de "checkout" op waardoor het (ENKELVOUDIG) INFORMATIEOBJECT
+    ontgrendeld wordt.
     """
     queryset = EnkelvoudigInformatieObject.objects.order_by('canonical', '-versie').distinct('canonical')
     lookup_field = 'uuid'
@@ -290,31 +312,41 @@ class ObjectInformatieObjectViewSet(NotificationCreateMixin,
                                     mixins.DestroyModelMixin,
                                     viewsets.ReadOnlyModelViewSet):
     """
-    Opvragen en bewerken van Object-Informatieobject relaties.
+    Opvragen en verwijderen van OBJECT-INFORMATIEOBJECT relaties.
+
+    Het betreft een relatie tussen een willekeurig OBJECT, bijvoorbeeld een
+    ZAAK in de Zaken API, en een INFORMATIEOBJECT.
 
     create:
-    OPGELET: dit endpoint hoor je als client NIET zelf aan te spreken.
+    Maak een OBJECT-INFORMATIEOBJECT relatie aan.
 
-    ZRC en BRC gebruiken deze endpoint bij het synchroniseren van relaties.
+    **LET OP: Dit endpoint hoor je als consumer niet zelf aan te spreken.**
 
-    Registreer welk(e) INFORMATIEOBJECT(en) een OBJECT kent.
+    Andere API's, zoals de Zaken API en de Besluiten API, gebruiken dit
+    endpoint bij het synchroniseren van relaties.
 
     **Er wordt gevalideerd op**
-    - geldigheid informatieobject URL
-    - uniek zijn van relatie OBJECT-INFORMATIEOBJECT
-    - bestaan van relatie OBJECT-INFORMATIEOBJECT in het ZRC of DRC (waar het
-      object leeft)
+    - geldigheid `informatieobject` URL
+    - de combinatie `informatieobject` en `object` moet uniek zijn
+    - bestaan van `object` URL
 
     list:
-    Geef een lijst van relaties tussen OBJECTen en INFORMATIEOBJECTen.
+    Alle OBJECT-INFORMATIEOBJECT relaties opvragen.
+
+    Deze lijst kan gefilterd wordt met query-string parameters.
 
     retrieve:
-    Geef een informatieobject terug wat gekoppeld is aan het huidige object
+    Een specifieke OBJECT-INFORMATIEOBJECT relatie opvragen.
+
+    Een specifieke OBJECT-INFORMATIEOBJECT relatie opvragen.
 
     destroy:
-    Verwijder een relatie tussen een object en een informatieobject.
-    OPGELET: dit endpoint hoor je als client NIET zelf aan te spreken, dit moet
-    gedaan worden door het ZRC/BRC
+    Verwijder een OBJECT-INFORMATIEOBJECT relatie.
+
+    **LET OP: Dit endpoint hoor je als consumer niet zelf aan te spreken.**
+
+    Andere API's, zoals de Zaken API en de Besluiten API, gebruiken dit
+    endpoint bij het synchroniseren van relaties.
     """
     queryset = ObjectInformatieObject.objects.all()
     serializer_class = ObjectInformatieObjectSerializer
@@ -353,34 +385,44 @@ class GebruiksrechtenViewSet(NotificationViewSetMixin,
                              AuditTrailViewsetMixin,
                              viewsets.ModelViewSet):
     """
-    list:
-    Geef een lijst van gebruiksrechten horend bij informatieobjecten.
-
-    Er kan gefiltered worden met querystringparameters.
-
-    retrieve:
-    Haal de details op van een gebruiksrecht van een informatieobject.
+    Opvragen en bewerken van GEBRUIKSRECHTen bij een INFORMATIEOBJECT.
 
     create:
-    Voeg gebruiksrechten toe voor een informatieobject.
+    Maak een GEBRUIKSRECHT aan.
+
+    Voeg GEBRUIKSRECHTen toe voor een INFORMATIEOBJECT.
 
     **Opmerkingen**
     - Het toevoegen van gebruiksrechten zorgt ervoor dat de
       `indicatieGebruiksrecht` op het informatieobject op `true` gezet wordt.
 
+    list:
+    Alle GEBRUIKSRECHTen opvragen.
+
+    Deze lijst kan gefilterd wordt met query-string parameters.
+
+    retrieve:
+    Een specifieke GEBRUIKSRECHT opvragen.
+
+    Een specifieke GEBRUIKSRECHT opvragen.
+
     update:
-    Werk een gebruiksrecht van een informatieobject bij.
+    Werk een GEBRUIKSRECHT in zijn geheel bij.
+
+    Werk een GEBRUIKSRECHT in zijn geheel bij.
 
     partial_update:
-    Werk een gebruiksrecht van een informatieobject bij.
+    Werk een GEBRUIKSRECHT relatie deels bij.
+
+    Werk een GEBRUIKSRECHT relatie deels bij.
 
     destroy:
-    Verwijder een gebruiksrecht van een informatieobject.
+    Verwijder een GEBRUIKSRECHT.
 
     **Opmerkingen**
-    - Indien het laatste gebruiksrecht van een informatieobject verwijderd wordt,
-      dan wordt de `indicatieGebruiksrecht` van het informatieobject op `null`
-      gezet.
+    - Indien het laatste GEBRUIKSRECHT van een INFORMATIEOBJECT verwijderd
+      wordt, dan wordt de `indicatieGebruiksrecht` van het INFORMATIEOBJECT op
+      `null` gezet.
     """
     queryset = Gebruiksrechten.objects.all()
     serializer_class = GebruiksrechtenSerializer
@@ -403,12 +445,16 @@ class GebruiksrechtenViewSet(NotificationViewSetMixin,
 
 class EnkelvoudigInformatieObjectAuditTrailViewSet(AuditTrailViewSet):
     """
-    Opvragen van Audit trails horend bij een EnkelvoudigInformatieObject.
+    Opvragen van de audit trail regels.
 
     list:
-    Geef een lijst van AUDITTRAILS die horen bij het huidige EnkelvoudigInformatieObject.
+    Alle audit trail regels behorend bij het INFORMATIEOBJECT.
+
+    Alle audit trail regels behorend bij het INFORMATIEOBJECT.
 
     retrieve:
-    Haal de details van een AUDITTRAIL op.
+    Een specifieke audit trail regel opvragen.
+
+    Een specifieke audit trail regel opvragen.
     """
     main_resource_lookup_field = 'enkelvoudiginformatieobject_uuid'

--- a/src/drc/conf/api.py
+++ b/src/drc/conf/api.py
@@ -28,7 +28,7 @@ SWAGGER_SETTINGS.update({
     # no geo things here
     'DEFAULT_FIELD_INSPECTORS': (
         'vng_api_common.inspectors.files.FileFieldInspector',
-    ) + BASE_SWAGGER_SETTINGS['DEFAULT_FIELD_INSPECTORS'][1:]
+    ) + BASE_SWAGGER_SETTINGS['DEFAULT_FIELD_INSPECTORS']
 })
 
 GEMMA_URL_INFORMATIEMODEL_VERSIE = '1.0'

--- a/src/drc/datamodel/models.py
+++ b/src/drc/datamodel/models.py
@@ -97,9 +97,9 @@ class InformatieObject(models.Model):
         _("indicatie gebruiksrecht"), blank=True, default=None,
         help_text=_("Indicatie of er beperkingen gelden aangaande het gebruik van "
                     "het informatieobject anders dan raadpleging. Dit veld mag "
-                    "'null' zijn om aan te geven dat de indicatie nog niet bekend is. "
+                    "`null' zijn om aan te geven dat de indicatie nog niet bekend is. "
                     "Als de indicatie gezet is, dan kan je de gebruiksrechten die "
-                    "van toepassing zijn raadplegen via de `Gebruiksrechten` resource.")
+                    "van toepassing zijn raadplegen via de `GEBRUIKSRECHTEN resource.")
     )
 
     # signing in some sort of way
@@ -117,7 +117,8 @@ class InformatieObject(models.Model):
     )
 
     informatieobjecttype = models.URLField(
-        help_text='URL naar de INFORMATIEOBJECTTYPE in het ZTC.'
+        help_text=_('URL-referentie naar het INFORMATIEOBJECTTYPE (in de '
+                    'Catalogi API).')
     )
 
     objects = InformatieobjectQuerySet.as_manager()
@@ -187,7 +188,9 @@ class EnkelvoudigInformatieObject(APIMixin, InformatieObject):
         help_text='Unieke resource identifier (UUID4)'
     )
 
-    # TODO: validate mime types
+    # NOTE: Don't validate but rely on externally maintened list of Media Types
+    # and that consumers know what they're doing. This prevents updating the
+    # API specification on every Media Type that is added.
     formaat = models.CharField(
         max_length=255, blank=True,
         help_text='Het "Media Type" (voorheen "MIME type") voor de wijze waarop'
@@ -195,7 +198,7 @@ class EnkelvoudigInformatieObject(APIMixin, InformatieObject):
                   'computerbestand. Voorbeeld: `application/msword`.'
     )
     taal = LanguageField(
-        help_text='Een taal van de intellectuele inhoud van het ENKELVOUDIG '
+        help_text='Een taal van de intellectuele inhoud van het '
                   'INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B'
     )
 
@@ -247,6 +250,7 @@ class Gebruiksrechten(models.Model):
     )
     informatieobject = models.ForeignKey(
         'EnkelvoudigInformatieObjectCanonical', on_delete=models.CASCADE,
+        help_text='URL-referentie naar het INFORMATIEOBJECT.'
     )
     omschrijving_voorwaarden = models.TextField(
         _("omschrijving voorwaarden"),
@@ -309,18 +313,21 @@ class ObjectInformatieObject(APIMixin, models.Model):
     )
     informatieobject = models.ForeignKey(
         'EnkelvoudigInformatieObjectCanonical', on_delete=models.CASCADE,
+        help_text='URL-referentie naar het INFORMATIEOBJECT.'
     )
-    object = models.URLField(help_text="URL naar het gerelateerde OBJECT.")
+    object = models.URLField(
+        help_text="URL-referentie naar het gerelateerde OBJECT (in deze of een "
+                  "andere API).")
     object_type = models.CharField(
-        "objecttype", max_length=100,
-        choices=ObjectTypes.choices
+        "objecttype", max_length=100, choices=ObjectTypes.choices,
+        help_text="Het type van het gerelateerde OBJECT."
     )
 
     objects = InformatieobjectRelatedQuerySet.as_manager()
 
     class Meta:
-        verbose_name = 'Zaakinformatieobject'
-        verbose_name_plural = 'Zaakinformatieobjecten'
+        verbose_name = 'Oobject-informatieobject'
+        verbose_name_plural = 'object-informatieobjecten'
         unique_together = ('informatieobject', 'object')
 
     def __str__(self):

--- a/src/drc/datamodel/models.py
+++ b/src/drc/datamodel/models.py
@@ -190,8 +190,9 @@ class EnkelvoudigInformatieObject(APIMixin, InformatieObject):
     # TODO: validate mime types
     formaat = models.CharField(
         max_length=255, blank=True,
-        help_text='De code voor de wijze waarop de inhoud van het ENKELVOUDIG '
-                  'INFORMATIEOBJECT is vastgelegd in een computerbestand.'
+        help_text='Het "Media Type" (voorheen "MIME type") voor de wijze waarop'
+                  'de inhoud van het INFORMATIEOBJECT is vastgelegd in een '
+                  'computerbestand. Voorbeeld: `application/msword`.'
     )
     taal = LanguageField(
         help_text='Een taal van de intellectuele inhoud van het ENKELVOUDIG '

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,48 +1,24 @@
 openapi: 3.0.0
 info:
-  title: Documentregistratiecomponent (drc) API
-  description: 'Een API om een documentregistratiecomponent te benaderen.
-
-
-    Een informatieobject is een digitaal document voorzien van meta-gegevens.
-
-    Informatieobjecten kunnen aan andere objecten zoals zaken en besluiten worden
-
-    gerelateerd (maar dat hoeft niet) en kunnen gebruiksrechten hebben.
-
-    Gebruiksrechten leggen voorwaarden op aan het gebruik van het informatieobject
-
-    (buiten raadpleging). Deze gebruiksrechten worden niet door de API gevalideerd
-
-    of gehandhaafd.
-
-
-    De typering van informatieobjecten is in de zaaktypecatalogus (ZTC)
-
-    ondergebracht in de vorm van informatieobjecttypen.
-
-
-    **Autorisatie**
-
-
-    Deze API vereist nog geen autorisatie. Je mag wel JWT-tokens gegenereerd door
-
-    de [token-tool](https://ref.tst.vng.cloud/tokens/) gebruiken - deze worden
-
-    voor nu genegeerd.
-
-
-    **Handige links**
-
-
-    * [Aan de slag](https://ref.tst.vng.cloud/ontwikkelaars/)
-
-    * ["Papieren" standaard](https://ref.tst.vng.cloud/standaard/)
-
-    '
+  title: Documenten API
+  description: "Een API om een documentregistratiecomponent (DRC) te benaderen.\n\n\
+    In een documentregistratiecomponent worden INFORMATIEOBJECTen opgeslagen. Een\
+    \ \nINFORMATIEOBJECT is een digitaal document voorzien van meta-gegevens. \nINFORMATIEOBJECTen\
+    \ kunnen aan andere objecten zoals zaken en besluiten worden \ngerelateerd (maar\
+    \ dat hoeft niet) en kunnen gebruiksrechten hebben. \n\nGEBRUIKSRECHTEN leggen\
+    \ voorwaarden op aan het gebruik van het INFORMATIEOBJECT\n(buiten raadpleging).\
+    \ Deze GEBRUIKSRECHTEN worden niet door de API gevalideerd\nof gehandhaafd.\n\n\
+    De typering van INFORMATIEOBJECTen is in de Catalogi API (ZTC) ondergebracht in\n\
+    de vorm van INFORMATIEOBJECTTYPEn.\n\n**Afhankelijkheden**\n\nDeze API is afhankelijk\
+    \ van:\n\n* Catalogi API\n* Notificaties API\n* Autorisaties API *(optioneel)*\n\
+    * Zaken API *(optioneel)*\n\n**Autorisatie**\n\nDeze API vereist autorisatie.\
+    \ Je kan de\n[token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens\
+    \ te\ngenereren.\n\n**Notificaties**\n\nDeze API publiceert notificaties op het\
+    \ kanaal `documenten`.\n\n**Handige links**\n\n* [Documentatie](https://zaakgerichtwerken.vng.cloud/standaard)\n\
+    * [Zaakgericht werken](https://zaakgerichtwerken.vng.cloud)\n"
   contact:
-    url: https://github.com/VNG-Realisatie/gemma-zaken
-    email: support@maykinmedia.nl
+    url: https://zaakgerichtwerken.vng.cloud
+    email: standaarden.ondersteuning@vng.nl
   license:
     name: EUPL 1.2
     url: https://opensource.org/licenses/EUPL-1.2
@@ -53,13 +29,13 @@ paths:
   /enkelvoudiginformatieobjecten:
     get:
       operationId: enkelvoudiginformatieobject_list
-      summary: 'Geef een lijst van de laatste versies van ENKELVOUDIGe INFORMATIEOBJECTen
+      summary: Alle (ENKELVOUDIGe) INFORMATIEOBJECTen opvragen.
+      description: 'Deze lijst kan gefilterd wordt met query-string parameters.
 
-        (=documenten).'
-      description: 'De objecten bevatten metadata over de documenten en de downloadlink
-        naar
 
-        de binary data.'
+        De objecten bevatten metadata over de documenten en de downloadlink
+
+        (`inhoud`) naar de binary data.'
       parameters:
       - name: identificatie
         in: query
@@ -84,7 +60,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -114,7 +90,7 @@ paths:
                     items:
                       $ref: '#/components/schemas/EnkelvoudigInformatieObject'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -126,7 +102,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -138,7 +114,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -150,7 +126,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -162,7 +138,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -174,7 +150,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -186,7 +162,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -198,7 +174,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -210,7 +186,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -228,10 +204,10 @@ paths:
         - documenten.lezen
     post:
       operationId: enkelvoudiginformatieobject_create
-      summary: Registreer een ENKELVOUDIG INFORMATIEOBJECT.
+      summary: Maak een (ENKELVOUDIG) INFORMATIEOBJECT aan.
       description: '**Er wordt gevalideerd op**
 
-        - geldigheid informatieobjecttype URL'
+        - geldigheid `informatieobjecttype` URL'
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -255,7 +231,7 @@ paths:
           type: string
       responses:
         '201':
-          description: ''
+          description: Created
           headers:
             API-version:
               schema:
@@ -272,7 +248,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnkelvoudigInformatieObjectData'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -284,7 +260,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -296,7 +272,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -308,7 +284,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -320,7 +296,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -332,7 +308,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -344,7 +320,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -356,7 +332,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -368,7 +344,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -394,10 +370,11 @@ paths:
   /enkelvoudiginformatieobjecten/{enkelvoudiginformatieobject_uuid}/audittrail:
     get:
       operationId: audittrail_list
-      description: Geef een lijst van AUDITTRAILS die horen bij het huidige EnkelvoudigInformatieObject.
+      summary: Alle audit trail regels behorend bij het INFORMATIEOBJECT.
+      description: Alle audit trail regels behorend bij het INFORMATIEOBJECT.
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -411,7 +388,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/AuditTrail'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -423,7 +400,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -435,7 +412,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -447,7 +424,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -459,7 +436,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -471,7 +448,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -483,7 +460,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -495,7 +472,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -522,10 +499,11 @@ paths:
   /enkelvoudiginformatieobjecten/{enkelvoudiginformatieobject_uuid}/audittrail/{uuid}:
     get:
       operationId: audittrail_read
-      description: Haal de details van een AUDITTRAIL op.
+      summary: Een specifieke audit trail regel opvragen.
+      description: Een specifieke audit trail regel opvragen.
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -537,7 +515,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuditTrail'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -549,7 +527,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -561,7 +539,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -573,7 +551,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -585,7 +563,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -597,7 +575,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -609,7 +587,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -621,7 +599,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -633,7 +611,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -667,14 +645,13 @@ paths:
   /enkelvoudiginformatieobjecten/{uuid}:
     get:
       operationId: enkelvoudiginformatieobject_read
-      summary: Geef de details van de laatste versie ENKELVOUDIG INFORMATIEOBJECT.
-      description: 'Het object bevat metadata over het informatieobject en de downloadlink
-        naar
-
-        de binary data.
+      summary: Een specifiek (ENKELVOUDIGe) INFORMATIEOBJECT opvragen.
+      description: 'Een specifiek (ENKELVOUDIGe) INFORMATIEOBJECT opvragen.
 
 
-        Er kan gefiltered worden met querystringparameters.'
+        Het object bevat metadata over het document en de downloadlink (`inhoud`)
+
+        naar de binary data.'
       parameters:
       - name: versie
         in: query
@@ -690,7 +667,7 @@ paths:
           type: string
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -702,7 +679,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnkelvoudigInformatieObject'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -714,7 +691,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -726,7 +703,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -738,7 +715,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -750,7 +727,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -762,7 +739,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -774,7 +751,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -786,7 +763,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -798,7 +775,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -816,13 +793,12 @@ paths:
         - documenten.lezen
     put:
       operationId: enkelvoudiginformatieobject_update
-      summary: 'Maak een nieuwe versie van een ENKELVOUDIG INFORMATIEOBJECT aan door
-        de
-
-        volledige resource mee te sturen.'
+      summary: Werk een (ENKELVOUDIG) INFORMATIEOBJECT in zijn geheel bij.
       description: '**Er wordt gevalideerd op**
 
-        - geldigheid informatieobjecttype URL
+        - correcte `lock` waarde
+
+        - geldigheid `informatieobjecttype` URL
 
 
         *TODO*
@@ -851,7 +827,7 @@ paths:
           type: string
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -863,7 +839,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnkelvoudigInformatieObjectWithLockData'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -875,7 +851,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -887,7 +863,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -899,7 +875,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -911,7 +887,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -923,7 +899,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -935,7 +911,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -947,7 +923,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -959,7 +935,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -971,7 +947,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -991,13 +967,12 @@ paths:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectWithLockData'
     patch:
       operationId: enkelvoudiginformatieobject_partial_update
-      summary: 'Maak een nieuwe versie van een ENKELVOUDIG INFORMATIEOBJECT aan door
-        enkel
-
-        de gewijzigde velden mee te sturen.'
+      summary: Werk een (ENKELVOUDIG) INFORMATIEOBJECT deels bij.
       description: '**Er wordt gevalideerd op**
 
-        - geldigheid informatieobjecttype URL
+        - correcte `lock` waarde
+
+        - geldigheid `informatieobjecttype` URL
 
 
         *TODO*
@@ -1026,7 +1001,7 @@ paths:
           type: string
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -1038,7 +1013,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnkelvoudigInformatieObjectWithLockData'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -1050,7 +1025,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -1062,7 +1037,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -1074,7 +1049,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -1086,7 +1061,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -1098,7 +1073,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -1110,7 +1085,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -1122,7 +1097,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -1134,7 +1109,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -1146,7 +1121,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -1166,7 +1141,8 @@ paths:
         $ref: '#/components/requestBodies/EnkelvoudigInformatieObjectWithLockData'
     delete:
       operationId: enkelvoudiginformatieobject_delete
-      description: 'Verwijdert een ENKELVOUDIG INFORMATIEOBJECT en alle bijbehorende
+      summary: Verwijder een (ENKELVOUDIG) INFORMATIEOBJECT.
+      description: 'Verwijder een (ENKELVOUDIG) INFORMATIEOBJECT en alle bijbehorende
         versies,
 
         samen met alle gerelateerde resources binnen deze API.
@@ -1174,9 +1150,11 @@ paths:
 
         **Gerelateerde resources**
 
-        - `ObjectInformatieObject` - alle relaties van het informatieobject
+        - OBJECT-INFORMATIEOBJECT
 
-        - `Gebruiksrechten` - alle gebruiksrechten van het informatieobject'
+        - GEBRUIKSRECHTen
+
+        - audit trail regels'
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -1200,7 +1178,7 @@ paths:
           type: string
       responses:
         '204':
-          description: ''
+          description: No content
           headers:
             API-version:
               schema:
@@ -1208,7 +1186,7 @@ paths:
               description: 'Geeft een specifieke API-versie aan in de context van
                 een specifieke aanroep. Voorbeeld: 1.2.1.'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -1220,7 +1198,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -1232,7 +1210,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -1244,7 +1222,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -1256,7 +1234,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -1268,7 +1246,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -1280,7 +1258,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -1292,7 +1270,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -1304,7 +1282,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -1331,7 +1309,8 @@ paths:
   /enkelvoudiginformatieobjecten/{uuid}/download:
     get:
       operationId: enkelvoudiginformatieobject_download
-      description: Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.
+      summary: Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT.
+      description: Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT.
       parameters:
       - name: versie
         in: query
@@ -1471,7 +1450,14 @@ paths:
   /enkelvoudiginformatieobjecten/{uuid}/lock:
     post:
       operationId: enkelvoudiginformatieobject_lock
-      description: Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.
+      summary: Vergrendel een (ENKELVOUDIG) INFORMATIEOBJECT.
+      description: 'Voert een "checkout" uit waardoor het (ENKELVOUDIG) INFORMATIEOBJECT
+
+        vergrendeld wordt met een `lock` waarde. Alleen met deze waarde kan het
+
+        (ENKELVOUDIG) INFORMATIEOBJECT bijgewerkt (`PUT`, `PATCH`) en weer
+
+        ontgrendeld worden.'
       responses:
         '200':
           description: ''
@@ -1615,7 +1601,10 @@ paths:
   /enkelvoudiginformatieobjecten/{uuid}/unlock:
     post:
       operationId: enkelvoudiginformatieobject_unlock
-      description: Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.
+      summary: Ontgrendel een (ENKELVOUDIG) INFORMATIEOBJECT.
+      description: 'Heft de "checkout" op waardoor het (ENKELVOUDIG) INFORMATIEOBJECT
+
+        ontgrendeld wordt.'
       responses:
         '204':
           description: No content
@@ -1755,12 +1744,12 @@ paths:
   /gebruiksrechten:
     get:
       operationId: gebruiksrechten_list
-      summary: Geef een lijst van gebruiksrechten horend bij informatieobjecten.
-      description: Er kan gefiltered worden met querystringparameters.
+      summary: Alle GEBRUIKSRECHTen opvragen.
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
       parameters:
       - name: informatieobject
         in: query
-        description: ''
+        description: URL-referentie naar het INFORMATIEOBJECT.
         required: false
         schema:
           type: string
@@ -1826,7 +1815,7 @@ paths:
           type: string
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -1840,7 +1829,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Gebruiksrechten'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -1852,7 +1841,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -1864,7 +1853,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -1876,7 +1865,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -1888,7 +1877,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -1900,7 +1889,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -1912,7 +1901,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -1924,7 +1913,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -1936,7 +1925,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -1954,10 +1943,10 @@ paths:
         - documenten.lezen
     post:
       operationId: gebruiksrechten_create
-      summary: Voeg gebruiksrechten toe voor een informatieobject.
-      description: "**Opmerkingen**\n- Het toevoegen van gebruiksrechten zorgt ervoor\
-        \ dat de\n  `indicatieGebruiksrecht` op het informatieobject op `true` gezet\
-        \ wordt."
+      summary: Maak een GEBRUIKSRECHT aan.
+      description: "Voeg GEBRUIKSRECHTen toe voor een INFORMATIEOBJECT.\n\n**Opmerkingen**\n\
+        - Het toevoegen van gebruiksrechten zorgt ervoor dat de\n  `indicatieGebruiksrecht`\
+        \ op het informatieobject op `true` gezet wordt."
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -1981,7 +1970,7 @@ paths:
           type: string
       responses:
         '201':
-          description: ''
+          description: Created
           headers:
             API-version:
               schema:
@@ -1998,7 +1987,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Gebruiksrechten'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -2010,7 +1999,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -2022,7 +2011,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -2034,7 +2023,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -2046,7 +2035,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -2058,7 +2047,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -2070,7 +2059,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -2082,7 +2071,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -2094,7 +2083,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -2116,10 +2105,11 @@ paths:
   /gebruiksrechten/{uuid}:
     get:
       operationId: gebruiksrechten_read
-      description: Haal de details op van een gebruiksrecht van een informatieobject.
+      summary: Een specifieke GEBRUIKSRECHT opvragen.
+      description: Een specifieke GEBRUIKSRECHT opvragen.
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -2131,7 +2121,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Gebruiksrechten'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -2143,7 +2133,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -2155,7 +2145,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -2167,7 +2157,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -2179,7 +2169,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -2191,7 +2181,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -2203,7 +2193,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -2215,7 +2205,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -2227,7 +2217,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -2245,7 +2235,8 @@ paths:
         - documenten.lezen
     put:
       operationId: gebruiksrechten_update
-      description: Werk een gebruiksrecht van een informatieobject bij.
+      summary: Werk een GEBRUIKSRECHT in zijn geheel bij.
+      description: Werk een GEBRUIKSRECHT in zijn geheel bij.
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -2269,7 +2260,7 @@ paths:
           type: string
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -2281,7 +2272,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Gebruiksrechten'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -2293,7 +2284,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -2305,7 +2296,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -2317,7 +2308,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -2329,7 +2320,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -2341,7 +2332,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -2353,7 +2344,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -2365,7 +2356,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -2377,7 +2368,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -2389,7 +2380,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -2409,7 +2400,8 @@ paths:
         $ref: '#/components/requestBodies/Gebruiksrechten'
     patch:
       operationId: gebruiksrechten_partial_update
-      description: Werk een gebruiksrecht van een informatieobject bij.
+      summary: Werk een GEBRUIKSRECHT relatie deels bij.
+      description: Werk een GEBRUIKSRECHT relatie deels bij.
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -2433,7 +2425,7 @@ paths:
           type: string
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -2445,7 +2437,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Gebruiksrechten'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -2457,7 +2449,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -2469,7 +2461,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -2481,7 +2473,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -2493,7 +2485,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -2505,7 +2497,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -2517,7 +2509,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -2529,7 +2521,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -2541,7 +2533,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -2553,7 +2545,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -2573,10 +2565,10 @@ paths:
         $ref: '#/components/requestBodies/Gebruiksrechten'
     delete:
       operationId: gebruiksrechten_delete
-      summary: Verwijder een gebruiksrecht van een informatieobject.
-      description: "**Opmerkingen**\n- Indien het laatste gebruiksrecht van een informatieobject\
-        \ verwijderd wordt,\n  dan wordt de `indicatieGebruiksrecht` van het informatieobject\
-        \ op `null`\n  gezet."
+      summary: Verwijder een GEBRUIKSRECHT.
+      description: "**Opmerkingen**\n- Indien het laatste GEBRUIKSRECHT van een INFORMATIEOBJECT\
+        \ verwijderd\n  wordt, dan wordt de `indicatieGebruiksrecht` van het INFORMATIEOBJECT\
+        \ op\n  `null` gezet."
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -2600,7 +2592,7 @@ paths:
           type: string
       responses:
         '204':
-          description: ''
+          description: No content
           headers:
             API-version:
               schema:
@@ -2608,7 +2600,7 @@ paths:
               description: 'Geeft een specifieke API-versie aan in de context van
                 een specifieke aanroep. Voorbeeld: 1.2.1.'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -2620,7 +2612,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -2632,7 +2624,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -2644,7 +2636,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -2656,7 +2648,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -2668,7 +2660,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -2680,7 +2672,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -2692,7 +2684,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -2704,7 +2696,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -2731,24 +2723,26 @@ paths:
   /objectinformatieobjecten:
     get:
       operationId: objectinformatieobject_list
-      description: Geef een lijst van relaties tussen OBJECTen en INFORMATIEOBJECTen.
+      summary: Alle OBJECT-INFORMATIEOBJECT relaties opvragen.
+      description: Deze lijst kan gefilterd wordt met query-string parameters.
       parameters:
       - name: object
         in: query
-        description: URL naar het gerelateerde OBJECT.
+        description: URL-referentie naar het gerelateerde OBJECT (in deze of een andere
+          API).
         required: false
         schema:
           type: string
           format: uri
       - name: informatieobject
         in: query
-        description: ''
+        description: URL-referentie naar het INFORMATIEOBJECT.
         required: false
         schema:
           type: string
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -2762,7 +2756,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ObjectInformatieObject'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -2774,7 +2768,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -2786,7 +2780,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -2798,7 +2792,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -2810,7 +2804,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -2822,7 +2816,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -2834,7 +2828,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -2846,7 +2840,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -2858,7 +2852,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -2876,7 +2870,22 @@ paths:
         - documenten.lezen
     post:
       operationId: objectinformatieobject_create
-      description: ''
+      summary: Maak een OBJECT-INFORMATIEOBJECT relatie aan.
+      description: '**LET OP: Dit endpoint hoor je als consumer niet zelf aan te spreken.**
+
+
+        Andere API''s, zoals de Zaken API en de Besluiten API, gebruiken dit
+
+        endpoint bij het synchroniseren van relaties.
+
+
+        **Er wordt gevalideerd op**
+
+        - geldigheid `informatieobject` URL
+
+        - de combinatie `informatieobject` en `object` moet uniek zijn
+
+        - bestaan van `object` URL'
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -2900,7 +2909,7 @@ paths:
           type: string
       responses:
         '201':
-          description: ''
+          description: Created
           headers:
             API-version:
               schema:
@@ -2917,7 +2926,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ObjectInformatieObject'
         '400':
-          description: ''
+          description: Bad request
           headers:
             API-version:
               schema:
@@ -2929,7 +2938,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidatieFout'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -2941,7 +2950,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -2953,7 +2962,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -2965,7 +2974,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -2977,7 +2986,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -2989,7 +2998,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -3001,7 +3010,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -3013,7 +3022,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -3039,11 +3048,11 @@ paths:
   /objectinformatieobjecten/{uuid}:
     get:
       operationId: objectinformatieobject_read
-      description: Geef een informatieobject terug wat gekoppeld is aan het huidige
-        object
+      summary: Een specifieke OBJECT-INFORMATIEOBJECT relatie opvragen.
+      description: Een specifieke OBJECT-INFORMATIEOBJECT relatie opvragen.
       responses:
         '200':
-          description: ''
+          description: OK
           headers:
             API-version:
               schema:
@@ -3055,7 +3064,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ObjectInformatieObject'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -3067,7 +3076,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -3079,7 +3088,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -3091,7 +3100,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -3103,7 +3112,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -3115,7 +3124,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -3127,7 +3136,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -3139,7 +3148,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -3151,7 +3160,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -3169,7 +3178,13 @@ paths:
         - documenten.lezen
     delete:
       operationId: objectinformatieobject_delete
-      description: Verwijder een relatie tussen een object en een informatieobject.
+      summary: Verwijder een OBJECT-INFORMATIEOBJECT relatie.
+      description: '**LET OP: Dit endpoint hoor je als consumer niet zelf aan te spreken.**
+
+
+        Andere API''s, zoals de Zaken API en de Besluiten API, gebruiken dit
+
+        endpoint bij het synchroniseren van relaties.'
       parameters:
       - name: X-NLX-Request-Application-Id
         in: header
@@ -3193,7 +3208,7 @@ paths:
           type: string
       responses:
         '204':
-          description: ''
+          description: No content
           headers:
             API-version:
               schema:
@@ -3201,7 +3216,7 @@ paths:
               description: 'Geeft een specifieke API-versie aan in de context van
                 een specifieke aanroep. Voorbeeld: 1.2.1.'
         '401':
-          description: ''
+          description: Unauthorized
           headers:
             API-version:
               schema:
@@ -3213,7 +3228,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '403':
-          description: ''
+          description: Forbidden
           headers:
             API-version:
               schema:
@@ -3225,7 +3240,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '404':
-          description: ''
+          description: Not_found
           headers:
             API-version:
               schema:
@@ -3237,7 +3252,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '406':
-          description: ''
+          description: Not acceptable
           headers:
             API-version:
               schema:
@@ -3249,7 +3264,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '409':
-          description: ''
+          description: Conflict
           headers:
             API-version:
               schema:
@@ -3261,7 +3276,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '410':
-          description: ''
+          description: Gone
           headers:
             API-version:
               schema:
@@ -3273,7 +3288,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '415':
-          description: ''
+          description: Unsupported media type
           headers:
             API-version:
               schema:
@@ -3285,7 +3300,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '429':
-          description: ''
+          description: Too many requests
           headers:
             API-version:
               schema:
@@ -3297,7 +3312,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Fout'
         '500':
-          description: ''
+          description: Internal server error
           headers:
             API-version:
               schema:
@@ -3418,9 +3433,13 @@ components:
       properties:
         url:
           title: Url
+          description: URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
           type: string
           format: uri
           readOnly: true
+          maxLength: 1000
+          minLength: 1
         identificatie:
           title: Identificatie
           description: Een binnen een gegeven context ondubbelzinnige referentie naar
@@ -3430,8 +3449,8 @@ components:
         bronorganisatie:
           title: Bronorganisatie
           description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie\
-            \ die het informatieobject heeft gecre\xEBerd of heeft ontvangen en als\
-            \ eerste in een samenwerkingsketen heeft vastgelegd."
+            \ die het informatieobject heeft gecre\xC3\xABerd of heeft ontvangen en\
+            \ als eerste in een samenwerkingsketen heeft vastgelegd."
           type: string
           maxLength: 9
           minLength: 1
@@ -3463,7 +3482,7 @@ components:
         auteur:
           title: Auteur
           description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
-            \ is voor het cre\xEBren van de inhoud van het INFORMATIEOBJECT."
+            \ is voor het cre\xC3\xABren van de inhoud van het INFORMATIEOBJECT."
           type: string
           maxLength: 200
           minLength: 1
@@ -3482,13 +3501,14 @@ components:
           - gearchiveerd
         formaat:
           title: Formaat
-          description: De code voor de wijze waarop de inhoud van het ENKELVOUDIG
-            INFORMATIEOBJECT is vastgelegd in een computerbestand.
+          description: 'Het "Media Type" (voorheen "MIME type") voor de wijze waaropde
+            inhoud van het INFORMATIEOBJECT is vastgelegd in een computerbestand.
+            Voorbeeld: `application/msword`.'
           type: string
           maxLength: 255
         taal:
           title: Taal
-          description: Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT.
+          description: Een taal van de intellectuele inhoud van het INFORMATIEOBJECT.
             De waardes komen uit ISO 639-2/B
           type: string
           enum:
@@ -3991,6 +4011,7 @@ components:
           readOnly: true
         bestandsomvang:
           title: Bestandsomvang
+          description: Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.
           type: integer
           readOnly: true
           minimum: 0
@@ -4032,10 +4053,10 @@ components:
         indicatieGebruiksrecht:
           title: Indicatie gebruiksrecht
           description: Indicatie of er beperkingen gelden aangaande het gebruik van
-            het informatieobject anders dan raadpleging. Dit veld mag 'null' zijn
+            het informatieobject anders dan raadpleging. Dit veld mag `null' zijn
             om aan te geven dat de indicatie nog niet bekend is. Als de indicatie
             gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen
-            via de `Gebruiksrechten` resource.
+            via de `GEBRUIKSRECHTEN resource.
           type: boolean
           nullable: true
         ondertekening:
@@ -4044,7 +4065,8 @@ components:
           $ref: '#/components/schemas/Integriteit'
         informatieobjecttype:
           title: Informatieobjecttype
-          description: URL naar de INFORMATIEOBJECTTYPE in het ZTC.
+          description: URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi
+            API).
           type: string
           format: uri
           maxLength: 200
@@ -4171,9 +4193,13 @@ components:
       properties:
         url:
           title: Url
+          description: URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
           type: string
           format: uri
           readOnly: true
+          maxLength: 1000
+          minLength: 1
         identificatie:
           title: Identificatie
           description: Een binnen een gegeven context ondubbelzinnige referentie naar
@@ -4183,8 +4209,8 @@ components:
         bronorganisatie:
           title: Bronorganisatie
           description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie\
-            \ die het informatieobject heeft gecre\xEBerd of heeft ontvangen en als\
-            \ eerste in een samenwerkingsketen heeft vastgelegd."
+            \ die het informatieobject heeft gecre\xC3\xABerd of heeft ontvangen en\
+            \ als eerste in een samenwerkingsketen heeft vastgelegd."
           type: string
           maxLength: 9
           minLength: 1
@@ -4216,7 +4242,7 @@ components:
         auteur:
           title: Auteur
           description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
-            \ is voor het cre\xEBren van de inhoud van het INFORMATIEOBJECT."
+            \ is voor het cre\xC3\xABren van de inhoud van het INFORMATIEOBJECT."
           type: string
           maxLength: 200
           minLength: 1
@@ -4235,13 +4261,14 @@ components:
           - gearchiveerd
         formaat:
           title: Formaat
-          description: De code voor de wijze waarop de inhoud van het ENKELVOUDIG
-            INFORMATIEOBJECT is vastgelegd in een computerbestand.
+          description: 'Het "Media Type" (voorheen "MIME type") voor de wijze waaropde
+            inhoud van het INFORMATIEOBJECT is vastgelegd in een computerbestand.
+            Voorbeeld: `application/msword`.'
           type: string
           maxLength: 255
         taal:
           title: Taal
-          description: Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT.
+          description: Een taal van de intellectuele inhoud van het INFORMATIEOBJECT.
             De waardes komen uit ISO 639-2/B
           type: string
           enum:
@@ -4738,11 +4765,12 @@ components:
           maxLength: 255
         inhoud:
           title: Inhoud
-          description: "Binaire inhoud, in base64 ge\xEBncodeerd."
+          description: "Binaire inhoud, in base64 ge\xC3\xABncodeerd."
           type: string
           format: bytes
         bestandsomvang:
           title: Bestandsomvang
+          description: Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.
           type: integer
           readOnly: true
           minimum: 0
@@ -4784,10 +4812,10 @@ components:
         indicatie_gebruiksrecht:
           title: Indicatie gebruiksrecht
           description: Indicatie of er beperkingen gelden aangaande het gebruik van
-            het informatieobject anders dan raadpleging. Dit veld mag 'null' zijn
+            het informatieobject anders dan raadpleging. Dit veld mag `null' zijn
             om aan te geven dat de indicatie nog niet bekend is. Als de indicatie
             gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen
-            via de `Gebruiksrechten` resource.
+            via de `GEBRUIKSRECHTEN resource.
           type: boolean
           nullable: true
         ondertekening:
@@ -4796,7 +4824,8 @@ components:
           $ref: '#/components/schemas/Integriteit'
         informatieobjecttype:
           title: Informatieobjecttype
-          description: URL naar de INFORMATIEOBJECTTYPE in het ZTC.
+          description: URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi
+            API).
           type: string
           format: uri
           maxLength: 200
@@ -4974,9 +5003,13 @@ components:
       properties:
         url:
           title: Url
+          description: URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
           type: string
           format: uri
           readOnly: true
+          maxLength: 1000
+          minLength: 1
         identificatie:
           title: Identificatie
           description: Een binnen een gegeven context ondubbelzinnige referentie naar
@@ -4986,8 +5019,8 @@ components:
         bronorganisatie:
           title: Bronorganisatie
           description: "Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie\
-            \ die het informatieobject heeft gecre\xEBerd of heeft ontvangen en als\
-            \ eerste in een samenwerkingsketen heeft vastgelegd."
+            \ die het informatieobject heeft gecre\xC3\xABerd of heeft ontvangen en\
+            \ als eerste in een samenwerkingsketen heeft vastgelegd."
           type: string
           maxLength: 9
           minLength: 1
@@ -5019,7 +5052,7 @@ components:
         auteur:
           title: Auteur
           description: "De persoon of organisatie die in de eerste plaats verantwoordelijk\
-            \ is voor het cre\xEBren van de inhoud van het INFORMATIEOBJECT."
+            \ is voor het cre\xC3\xABren van de inhoud van het INFORMATIEOBJECT."
           type: string
           maxLength: 200
           minLength: 1
@@ -5038,13 +5071,14 @@ components:
           - gearchiveerd
         formaat:
           title: Formaat
-          description: De code voor de wijze waarop de inhoud van het ENKELVOUDIG
-            INFORMATIEOBJECT is vastgelegd in een computerbestand.
+          description: 'Het "Media Type" (voorheen "MIME type") voor de wijze waaropde
+            inhoud van het INFORMATIEOBJECT is vastgelegd in een computerbestand.
+            Voorbeeld: `application/msword`.'
           type: string
           maxLength: 255
         taal:
           title: Taal
-          description: Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT.
+          description: Een taal van de intellectuele inhoud van het INFORMATIEOBJECT.
             De waardes komen uit ISO 639-2/B
           type: string
           enum:
@@ -5541,11 +5575,12 @@ components:
           maxLength: 255
         inhoud:
           title: Inhoud
-          description: "Binaire inhoud, in base64 ge\xEBncodeerd."
+          description: "Binaire inhoud, in base64 ge\xC3\xABncodeerd."
           type: string
           format: bytes
         bestandsomvang:
           title: Bestandsomvang
+          description: Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.
           type: integer
           readOnly: true
           minimum: 0
@@ -5587,10 +5622,10 @@ components:
         indicatie_gebruiksrecht:
           title: Indicatie gebruiksrecht
           description: Indicatie of er beperkingen gelden aangaande het gebruik van
-            het informatieobject anders dan raadpleging. Dit veld mag 'null' zijn
+            het informatieobject anders dan raadpleging. Dit veld mag `null' zijn
             om aan te geven dat de indicatie nog niet bekend is. Als de indicatie
             gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen
-            via de `Gebruiksrechten` resource.
+            via de `GEBRUIKSRECHTEN resource.
           type: boolean
           nullable: true
         ondertekening:
@@ -5599,7 +5634,8 @@ components:
           $ref: '#/components/schemas/Integriteit'
         informatieobjecttype:
           title: Informatieobjecttype
-          description: URL naar de INFORMATIEOBJECTTYPE in het ZTC.
+          description: URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi
+            API).
           type: string
           format: uri
           maxLength: 200
@@ -5643,11 +5679,16 @@ components:
       properties:
         url:
           title: Url
+          description: URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
           type: string
           format: uri
           readOnly: true
+          maxLength: 1000
+          minLength: 1
         informatieobject:
           title: Informatieobject
+          description: URL-referentie naar het INFORMATIEOBJECT.
           type: string
           format: uri
         startdatum:
@@ -5679,22 +5720,29 @@ components:
       properties:
         url:
           title: Url
+          description: URL-referentie naar dit object. Dit is de unieke identificatie
+            en locatie van dit object.
           type: string
           format: uri
           readOnly: true
+          maxLength: 1000
+          minLength: 1
         informatieobject:
           title: Informatieobject
+          description: URL-referentie naar het INFORMATIEOBJECT.
           type: string
           format: uri
         object:
           title: Object
-          description: URL naar het gerelateerde OBJECT.
+          description: URL-referentie naar het gerelateerde OBJECT (in deze of een
+            andere API).
           type: string
           format: uri
           maxLength: 200
           minLength: 1
         objectType:
           title: Objecttype
+          description: Het type van het gerelateerde OBJECT.
           type: string
           enum:
           - besluit

--- a/src/resources.md
+++ b/src/resources.md
@@ -10,7 +10,7 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/o
 
 | Attribuut | Omschrijving | Type | Verplicht | CRUD* |
 | --- | --- | --- | --- | --- |
-| url |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| url | URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object. | string | nee | ~~C~~​R​~~U~~​~~D~~ |
 | identificatie | Een binnen een gegeven context ondubbelzinnige referentie naar het INFORMATIEOBJECT. | string | nee | C​R​U​D |
 | bronorganisatie | Het RSIN van de Niet-natuurlijk persoon zijnde de organisatie die het informatieobject heeft gecreëerd of heeft ontvangen en als eerste in een samenwerkingsketen heeft vastgelegd. | string | ja | C​R​U​D |
 | creatiedatum | Een datum of een gebeurtenis in de levenscyclus van het INFORMATIEOBJECT. | string | ja | C​R​U​D |
@@ -18,17 +18,17 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/o
 | vertrouwelijkheidaanduiding | Aanduiding van de mate waarin het INFORMATIEOBJECT voor de openbaarheid bestemd is. | string | nee | C​R​U​D |
 | auteur | De persoon of organisatie die in de eerste plaats verantwoordelijk is voor het creëren van de inhoud van het INFORMATIEOBJECT. | string | ja | C​R​U​D |
 | status | Aanduiding van de stand van zaken van een INFORMATIEOBJECT. De waarden &#39;in bewerking&#39; en &#39;ter vaststelling&#39; komen niet voor als het attribuut `ontvangstdatum` van een waarde is voorzien. Wijziging van de Status in &#39;gearchiveerd&#39; impliceert dat het informatieobject een duurzaam, niet-wijzigbaar Formaat dient te hebben. | string | nee | C​R​U​D |
-| formaat | De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand. | string | nee | C​R​U​D |
-| taal | Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B | string | ja | C​R​U​D |
+| formaat | Het &quot;Media Type&quot; (voorheen &quot;MIME type&quot;) voor de wijze waaropde inhoud van het INFORMATIEOBJECT is vastgelegd in een computerbestand. Voorbeeld: `application/msword`. | string | nee | C​R​U​D |
+| taal | Een taal van de intellectuele inhoud van het INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B | string | ja | C​R​U​D |
 | bestandsnaam | De naam van het fysieke bestand waarin de inhoud van het informatieobject is vastgelegd, inclusief extensie. | string | nee | C​R​U​D |
 | inhoud | Download URL van de binaire inhoud. | string | nee | ~~C~~​R​~~U~~​~~D~~ |
-| bestandsomvang |  | integer | nee | ~~C~~​R​~~U~~​~~D~~ |
+| bestandsomvang | Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt. | integer | nee | ~~C~~​R​~~U~~​~~D~~ |
 | link | De URL waarmee de inhoud van het INFORMATIEOBJECT op te vragen is. | string | nee | C​R​U​D |
 | beschrijving | Een generieke beschrijving van de inhoud van het INFORMATIEOBJECT. | string | nee | C​R​U​D |
 | ontvangstdatum | De datum waarop het INFORMATIEOBJECT ontvangen is. Verplicht te registreren voor INFORMATIEOBJECTen die van buiten de zaakbehandelende organisatie(s) ontvangen zijn. Ontvangst en verzending is voorbehouden aan documenten die van of naar andere personen ontvangen of verzonden zijn waarbij die personen niet deel uit maken van de behandeling van de zaak waarin het document een rol speelt. | string | nee | C​R​U​D |
 | verzenddatum | De datum waarop het INFORMATIEOBJECT verzonden is, zoals deze op het INFORMATIEOBJECT vermeld is. Dit geldt voor zowel inkomende als uitgaande INFORMATIEOBJECTen. Eenzelfde informatieobject kan niet tegelijk inkomend en uitgaand zijn. Ontvangst en verzending is voorbehouden aan documenten die van of naar andere personen ontvangen of verzonden zijn waarbij die personen niet deel uit maken van de behandeling van de zaak waarin het document een rol speelt. | string | nee | C​R​U​D |
-| indicatieGebruiksrecht | Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag &#39;null&#39; zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `Gebruiksrechten` resource. | boolean | nee | C​R​U​D |
-| informatieobjecttype | URL naar de INFORMATIEOBJECTTYPE in het ZTC. | string | ja | C​R​U​D |
+| indicatieGebruiksrecht | Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag `null&#39; zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `GEBRUIKSRECHTEN resource. | boolean | nee | C​R​U​D |
+| informatieobjecttype | URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API). | string | ja | C​R​U​D |
 | locked | Geeft aan of het document gelocked is. Alleen als een document gelocked is, mogen er aanpassingen gemaakt worden. | boolean | nee | ~~C~~​R​~~U~~​~~D~~ |
 
 ## AuditTrail
@@ -79,8 +79,8 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/o
 
 | Attribuut | Omschrijving | Type | Verplicht | CRUD* |
 | --- | --- | --- | --- | --- |
-| url |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
-| informatieobject |  | string | ja | C​R​U​D |
+| url | URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object. | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| informatieobject | URL-referentie naar het INFORMATIEOBJECT. | string | ja | C​R​U​D |
 | startdatum | Begindatum van de periode waarin de gebruiksrechtvoorwaarden van toepassing zijn. Doorgaans is de datum van creatie van het informatieobject de startdatum. | string | ja | C​R​U​D |
 | einddatum | Einddatum van de periode waarin de gebruiksrechtvoorwaarden van toepassing zijn. | string | nee | C​R​U​D |
 | omschrijvingVoorwaarden | Omschrijving van de van toepassing zijnde voorwaarden aan het gebruik anders dan raadpleging | string | ja | C​R​U​D |
@@ -91,10 +91,10 @@ Objecttype op [GEMMA Online](https://www.gemmaonline.nl/index.php/Rgbz_1.0/doc/o
 
 | Attribuut | Omschrijving | Type | Verplicht | CRUD* |
 | --- | --- | --- | --- | --- |
-| url |  | string | nee | ~~C~~​R​~~U~~​~~D~~ |
-| informatieobject |  | string | ja | C​R​U​D |
-| object | URL naar het gerelateerde OBJECT. | string | ja | C​R​U​D |
-| objectType |  | string | ja | C​R​U​D |
+| url | URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object. | string | nee | ~~C~~​R​~~U~~​~~D~~ |
+| informatieobject | URL-referentie naar het INFORMATIEOBJECT. | string | ja | C​R​U​D |
+| object | URL-referentie naar het gerelateerde OBJECT (in deze of een andere API). | string | ja | C​R​U​D |
+| objectType | Het type van het gerelateerde OBJECT. | string | ja | C​R​U​D |
 
 
 * Create, Read, Update, Delete

--- a/src/swagger2.0.json
+++ b/src/swagger2.0.json
@@ -1,11 +1,11 @@
 {
     "swagger": "2.0",
     "info": {
-        "title": "Documentregistratiecomponent (drc) API",
-        "description": "Een API om een documentregistratiecomponent te benaderen.\n\nEen informatieobject is een digitaal document voorzien van meta-gegevens.\nInformatieobjecten kunnen aan andere objecten zoals zaken en besluiten worden\ngerelateerd (maar dat hoeft niet) en kunnen gebruiksrechten hebben.\nGebruiksrechten leggen voorwaarden op aan het gebruik van het informatieobject\n(buiten raadpleging). Deze gebruiksrechten worden niet door de API gevalideerd\nof gehandhaafd.\n\nDe typering van informatieobjecten is in de zaaktypecatalogus (ZTC)\nondergebracht in de vorm van informatieobjecttypen.\n\n**Autorisatie**\n\nDeze API vereist nog geen autorisatie. Je mag wel JWT-tokens gegenereerd door\nde [token-tool](https://ref.tst.vng.cloud/tokens/) gebruiken - deze worden\nvoor nu genegeerd.\n\n**Handige links**\n\n* [Aan de slag](https://ref.tst.vng.cloud/ontwikkelaars/)\n* [\"Papieren\" standaard](https://ref.tst.vng.cloud/standaard/)\n",
+        "title": "Documenten API",
+        "description": "Een API om een documentregistratiecomponent (DRC) te benaderen.\n\nIn een documentregistratiecomponent worden INFORMATIEOBJECTen opgeslagen. Een \nINFORMATIEOBJECT is een digitaal document voorzien van meta-gegevens. \nINFORMATIEOBJECTen kunnen aan andere objecten zoals zaken en besluiten worden \ngerelateerd (maar dat hoeft niet) en kunnen gebruiksrechten hebben. \n\nGEBRUIKSRECHTEN leggen voorwaarden op aan het gebruik van het INFORMATIEOBJECT\n(buiten raadpleging). Deze GEBRUIKSRECHTEN worden niet door de API gevalideerd\nof gehandhaafd.\n\nDe typering van INFORMATIEOBJECTen is in de Catalogi API (ZTC) ondergebracht in\nde vorm van INFORMATIEOBJECTTYPEn.\n\n**Afhankelijkheden**\n\nDeze API is afhankelijk van:\n\n* Catalogi API\n* Notificaties API\n* Autorisaties API *(optioneel)*\n* Zaken API *(optioneel)*\n\n**Autorisatie**\n\nDeze API vereist autorisatie. Je kan de\n[token-tool](https://zaken-auth.vng.cloud/) gebruiken om JWT-tokens te\ngenereren.\n\n**Notificaties**\n\nDeze API publiceert notificaties op het kanaal `documenten`.\n\n**Handige links**\n\n* [Documentatie](https://zaakgerichtwerken.vng.cloud/standaard)\n* [Zaakgericht werken](https://zaakgerichtwerken.vng.cloud)\n",
         "contact": {
-            "url": "https://github.com/VNG-Realisatie/gemma-zaken",
-            "email": "support@maykinmedia.nl"
+            "url": "https://zaakgerichtwerken.vng.cloud",
+            "email": "standaarden.ondersteuning@vng.nl"
         },
         "license": {
             "name": "EUPL 1.2",
@@ -36,8 +36,8 @@
         "/enkelvoudiginformatieobjecten": {
             "get": {
                 "operationId": "enkelvoudiginformatieobject_list",
-                "summary": "Geef een lijst van de laatste versies van ENKELVOUDIGe INFORMATIEOBJECTen\n(=documenten).",
-                "description": "De objecten bevatten metadata over de documenten en de downloadlink naar\nde binary data.",
+                "summary": "Alle (ENKELVOUDIGe) INFORMATIEOBJECTen opvragen.",
+                "description": "Deze lijst kan gefilterd wordt met query-string parameters.\n\nDe objecten bevatten metadata over de documenten en de downloadlink\n(`inhoud`) naar de binary data.",
                 "parameters": [
                     {
                         "name": "identificatie",
@@ -63,7 +63,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "required": [
                                 "count",
@@ -102,7 +102,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -116,7 +116,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -130,7 +130,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -144,7 +144,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -158,7 +158,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -172,7 +172,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -186,7 +186,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -200,7 +200,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -214,7 +214,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -241,8 +241,8 @@
             },
             "post": {
                 "operationId": "enkelvoudiginformatieobject_create",
-                "summary": "Registreer een ENKELVOUDIG INFORMATIEOBJECT.",
-                "description": "**Er wordt gevalideerd op**\n- geldigheid informatieobjecttype URL",
+                "summary": "Maak een (ENKELVOUDIG) INFORMATIEOBJECT aan.",
+                "description": "**Er wordt gevalideerd op**\n- geldigheid `informatieobjecttype` URL",
                 "parameters": [
                     {
                         "name": "data",
@@ -276,7 +276,7 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "",
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/EnkelvoudigInformatieObjectData"
                         },
@@ -297,7 +297,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -311,7 +311,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -325,7 +325,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -339,7 +339,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -353,7 +353,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -367,7 +367,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -381,7 +381,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -395,7 +395,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -409,7 +409,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -439,11 +439,12 @@
         "/enkelvoudiginformatieobjecten/{enkelvoudiginformatieobject_uuid}/audittrail": {
             "get": {
                 "operationId": "audittrail_list",
-                "description": "Geef een lijst van AUDITTRAILS die horen bij het huidige EnkelvoudigInformatieObject.",
+                "summary": "Alle audit trail regels behorend bij het INFORMATIEOBJECT.",
+                "description": "Alle audit trail regels behorend bij het INFORMATIEOBJECT.",
                 "parameters": [],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
@@ -460,7 +461,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -474,7 +475,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -488,7 +489,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -502,7 +503,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -516,7 +517,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -530,7 +531,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -544,7 +545,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -558,7 +559,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -597,11 +598,12 @@
         "/enkelvoudiginformatieobjecten/{enkelvoudiginformatieobject_uuid}/audittrail/{uuid}": {
             "get": {
                 "operationId": "audittrail_read",
-                "description": "Haal de details van een AUDITTRAIL op.",
+                "summary": "Een specifieke audit trail regel opvragen.",
+                "description": "Een specifieke audit trail regel opvragen.",
                 "parameters": [],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/AuditTrail"
                         },
@@ -615,7 +617,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -629,7 +631,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -643,7 +645,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -657,7 +659,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -671,7 +673,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -685,7 +687,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -699,7 +701,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -713,7 +715,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -727,7 +729,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -774,8 +776,8 @@
         "/enkelvoudiginformatieobjecten/{uuid}": {
             "get": {
                 "operationId": "enkelvoudiginformatieobject_read",
-                "summary": "Geef de details van de laatste versie ENKELVOUDIG INFORMATIEOBJECT.",
-                "description": "Het object bevat metadata over het informatieobject en de downloadlink naar\nde binary data.\n\nEr kan gefiltered worden met querystringparameters.",
+                "summary": "Een specifiek (ENKELVOUDIGe) INFORMATIEOBJECT opvragen.",
+                "description": "Een specifiek (ENKELVOUDIGe) INFORMATIEOBJECT opvragen.\n\nHet object bevat metadata over het document en de downloadlink (`inhoud`)\nnaar de binary data.",
                 "parameters": [
                     {
                         "name": "versie",
@@ -792,7 +794,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/EnkelvoudigInformatieObject"
                         },
@@ -806,7 +808,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -820,7 +822,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -834,7 +836,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -848,7 +850,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -862,7 +864,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -876,7 +878,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -890,7 +892,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -904,7 +906,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -918,7 +920,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -945,8 +947,8 @@
             },
             "put": {
                 "operationId": "enkelvoudiginformatieobject_update",
-                "summary": "Maak een nieuwe versie van een ENKELVOUDIG INFORMATIEOBJECT aan door de\nvolledige resource mee te sturen.",
-                "description": "**Er wordt gevalideerd op**\n- geldigheid informatieobjecttype URL\n\n*TODO*\n- valideer immutable attributes",
+                "summary": "Werk een (ENKELVOUDIG) INFORMATIEOBJECT in zijn geheel bij.",
+                "description": "**Er wordt gevalideerd op**\n- correcte `lock` waarde\n- geldigheid `informatieobjecttype` URL\n\n*TODO*\n- valideer immutable attributes",
                 "parameters": [
                     {
                         "name": "data",
@@ -980,7 +982,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/EnkelvoudigInformatieObjectWithLockData"
                         },
@@ -994,7 +996,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -1008,7 +1010,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1022,7 +1024,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1036,7 +1038,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1050,7 +1052,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1064,7 +1066,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1078,7 +1080,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1092,7 +1094,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1106,7 +1108,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1120,7 +1122,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1147,8 +1149,8 @@
             },
             "patch": {
                 "operationId": "enkelvoudiginformatieobject_partial_update",
-                "summary": "Maak een nieuwe versie van een ENKELVOUDIG INFORMATIEOBJECT aan door enkel\nde gewijzigde velden mee te sturen.",
-                "description": "**Er wordt gevalideerd op**\n- geldigheid informatieobjecttype URL\n\n*TODO*\n- valideer immutable attributes",
+                "summary": "Werk een (ENKELVOUDIG) INFORMATIEOBJECT deels bij.",
+                "description": "**Er wordt gevalideerd op**\n- correcte `lock` waarde\n- geldigheid `informatieobjecttype` URL\n\n*TODO*\n- valideer immutable attributes",
                 "parameters": [
                     {
                         "name": "data",
@@ -1182,7 +1184,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/EnkelvoudigInformatieObjectWithLockData"
                         },
@@ -1196,7 +1198,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -1210,7 +1212,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1224,7 +1226,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1238,7 +1240,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1252,7 +1254,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1266,7 +1268,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1280,7 +1282,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1294,7 +1296,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1308,7 +1310,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1322,7 +1324,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1349,7 +1351,8 @@
             },
             "delete": {
                 "operationId": "enkelvoudiginformatieobject_delete",
-                "description": "Verwijdert een ENKELVOUDIG INFORMATIEOBJECT en alle bijbehorende versies,\nsamen met alle gerelateerde resources binnen deze API.\n\n**Gerelateerde resources**\n- `ObjectInformatieObject` - alle relaties van het informatieobject\n- `Gebruiksrechten` - alle gebruiksrechten van het informatieobject",
+                "summary": "Verwijder een (ENKELVOUDIG) INFORMATIEOBJECT.",
+                "description": "Verwijder een (ENKELVOUDIG) INFORMATIEOBJECT en alle bijbehorende versies,\nsamen met alle gerelateerde resources binnen deze API.\n\n**Gerelateerde resources**\n- OBJECT-INFORMATIEOBJECT\n- GEBRUIKSRECHTen\n- audit trail regels",
                 "parameters": [
                     {
                         "name": "X-NLX-Request-Application-Id",
@@ -1375,7 +1378,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "",
+                        "description": "No content",
                         "headers": {
                             "API-version": {
                                 "schema": {
@@ -1386,7 +1389,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1400,7 +1403,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1414,7 +1417,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1428,7 +1431,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1442,7 +1445,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1456,7 +1459,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1470,7 +1473,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1484,7 +1487,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1498,7 +1501,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -1537,7 +1540,8 @@
         "/enkelvoudiginformatieobjecten/{uuid}/download": {
             "get": {
                 "operationId": "enkelvoudiginformatieobject_download",
-                "description": "Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.",
+                "summary": "Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT.",
+                "description": "Download de binaire data van het (ENKELVOUDIG) INFORMATIEOBJECT.",
                 "parameters": [
                     {
                         "name": "versie",
@@ -1708,7 +1712,8 @@
         "/enkelvoudiginformatieobjecten/{uuid}/lock": {
             "post": {
                 "operationId": "enkelvoudiginformatieobject_lock",
-                "description": "Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.",
+                "summary": "Vergrendel een (ENKELVOUDIG) INFORMATIEOBJECT.",
+                "description": "Voert een \"checkout\" uit waardoor het (ENKELVOUDIG) INFORMATIEOBJECT\nvergrendeld wordt met een `lock` waarde. Alleen met deze waarde kan het\n(ENKELVOUDIG) INFORMATIEOBJECT bijgewerkt (`PUT`, `PATCH`) en weer\nontgrendeld worden.",
                 "parameters": [
                     {
                         "name": "data",
@@ -1886,7 +1891,8 @@
         "/enkelvoudiginformatieobjecten/{uuid}/unlock": {
             "post": {
                 "operationId": "enkelvoudiginformatieobject_unlock",
-                "description": "Ontsluit ENKELVOUDIG INFORMATIEOBJECTen.",
+                "summary": "Ontgrendel een (ENKELVOUDIG) INFORMATIEOBJECT.",
+                "description": "Heft de \"checkout\" op waardoor het (ENKELVOUDIG) INFORMATIEOBJECT\nontgrendeld wordt.",
                 "parameters": [
                     {
                         "name": "data",
@@ -2061,13 +2067,13 @@
         "/gebruiksrechten": {
             "get": {
                 "operationId": "gebruiksrechten_list",
-                "summary": "Geef een lijst van gebruiksrechten horend bij informatieobjecten.",
-                "description": "Er kan gefiltered worden met querystringparameters.",
+                "summary": "Alle GEBRUIKSRECHTen opvragen.",
+                "description": "Deze lijst kan gefilterd wordt met query-string parameters.",
                 "parameters": [
                     {
                         "name": "informatieobject",
                         "in": "query",
-                        "description": "",
+                        "description": "URL-referentie naar het INFORMATIEOBJECT.",
                         "required": false,
                         "type": "string"
                     },
@@ -2130,7 +2136,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
@@ -2147,7 +2153,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -2161,7 +2167,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2175,7 +2181,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2189,7 +2195,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2203,7 +2209,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2217,7 +2223,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2231,7 +2237,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2245,7 +2251,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2259,7 +2265,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2286,8 +2292,8 @@
             },
             "post": {
                 "operationId": "gebruiksrechten_create",
-                "summary": "Voeg gebruiksrechten toe voor een informatieobject.",
-                "description": "**Opmerkingen**\n- Het toevoegen van gebruiksrechten zorgt ervoor dat de\n  `indicatieGebruiksrecht` op het informatieobject op `true` gezet wordt.",
+                "summary": "Maak een GEBRUIKSRECHT aan.",
+                "description": "Voeg GEBRUIKSRECHTen toe voor een INFORMATIEOBJECT.\n\n**Opmerkingen**\n- Het toevoegen van gebruiksrechten zorgt ervoor dat de\n  `indicatieGebruiksrecht` op het informatieobject op `true` gezet wordt.",
                 "parameters": [
                     {
                         "name": "data",
@@ -2321,7 +2327,7 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "",
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/Gebruiksrechten"
                         },
@@ -2342,7 +2348,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -2356,7 +2362,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2370,7 +2376,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2384,7 +2390,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2398,7 +2404,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2412,7 +2418,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2426,7 +2432,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2440,7 +2446,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2454,7 +2460,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2484,11 +2490,12 @@
         "/gebruiksrechten/{uuid}": {
             "get": {
                 "operationId": "gebruiksrechten_read",
-                "description": "Haal de details op van een gebruiksrecht van een informatieobject.",
+                "summary": "Een specifieke GEBRUIKSRECHT opvragen.",
+                "description": "Een specifieke GEBRUIKSRECHT opvragen.",
                 "parameters": [],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/Gebruiksrechten"
                         },
@@ -2502,7 +2509,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2516,7 +2523,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2530,7 +2537,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2544,7 +2551,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2558,7 +2565,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2572,7 +2579,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2586,7 +2593,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2600,7 +2607,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2614,7 +2621,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2641,7 +2648,8 @@
             },
             "put": {
                 "operationId": "gebruiksrechten_update",
-                "description": "Werk een gebruiksrecht van een informatieobject bij.",
+                "summary": "Werk een GEBRUIKSRECHT in zijn geheel bij.",
+                "description": "Werk een GEBRUIKSRECHT in zijn geheel bij.",
                 "parameters": [
                     {
                         "name": "data",
@@ -2675,7 +2683,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/Gebruiksrechten"
                         },
@@ -2689,7 +2697,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -2703,7 +2711,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2717,7 +2725,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2731,7 +2739,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2745,7 +2753,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2759,7 +2767,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2773,7 +2781,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2787,7 +2795,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2801,7 +2809,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2815,7 +2823,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2842,7 +2850,8 @@
             },
             "patch": {
                 "operationId": "gebruiksrechten_partial_update",
-                "description": "Werk een gebruiksrecht van een informatieobject bij.",
+                "summary": "Werk een GEBRUIKSRECHT relatie deels bij.",
+                "description": "Werk een GEBRUIKSRECHT relatie deels bij.",
                 "parameters": [
                     {
                         "name": "data",
@@ -2876,7 +2885,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/Gebruiksrechten"
                         },
@@ -2890,7 +2899,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -2904,7 +2913,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2918,7 +2927,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2932,7 +2941,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2946,7 +2955,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2960,7 +2969,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2974,7 +2983,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -2988,7 +2997,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3002,7 +3011,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3016,7 +3025,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3043,8 +3052,8 @@
             },
             "delete": {
                 "operationId": "gebruiksrechten_delete",
-                "summary": "Verwijder een gebruiksrecht van een informatieobject.",
-                "description": "**Opmerkingen**\n- Indien het laatste gebruiksrecht van een informatieobject verwijderd wordt,\n  dan wordt de `indicatieGebruiksrecht` van het informatieobject op `null`\n  gezet.",
+                "summary": "Verwijder een GEBRUIKSRECHT.",
+                "description": "**Opmerkingen**\n- Indien het laatste GEBRUIKSRECHT van een INFORMATIEOBJECT verwijderd\n  wordt, dan wordt de `indicatieGebruiksrecht` van het INFORMATIEOBJECT op\n  `null` gezet.",
                 "parameters": [
                     {
                         "name": "X-NLX-Request-Application-Id",
@@ -3070,7 +3079,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "",
+                        "description": "No content",
                         "headers": {
                             "API-version": {
                                 "schema": {
@@ -3081,7 +3090,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3095,7 +3104,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3109,7 +3118,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3123,7 +3132,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3137,7 +3146,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3151,7 +3160,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3165,7 +3174,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3179,7 +3188,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3193,7 +3202,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3232,12 +3241,13 @@
         "/objectinformatieobjecten": {
             "get": {
                 "operationId": "objectinformatieobject_list",
-                "description": "Geef een lijst van relaties tussen OBJECTen en INFORMATIEOBJECTen.",
+                "summary": "Alle OBJECT-INFORMATIEOBJECT relaties opvragen.",
+                "description": "Deze lijst kan gefilterd wordt met query-string parameters.",
                 "parameters": [
                     {
                         "name": "object",
                         "in": "query",
-                        "description": "URL naar het gerelateerde OBJECT.",
+                        "description": "URL-referentie naar het gerelateerde OBJECT (in deze of een andere API).",
                         "required": false,
                         "type": "string",
                         "format": "uri"
@@ -3245,14 +3255,14 @@
                     {
                         "name": "informatieobject",
                         "in": "query",
-                        "description": "",
+                        "description": "URL-referentie naar het INFORMATIEOBJECT.",
                         "required": false,
                         "type": "string"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
@@ -3269,7 +3279,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -3283,7 +3293,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3297,7 +3307,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3311,7 +3321,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3325,7 +3335,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3339,7 +3349,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3353,7 +3363,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3367,7 +3377,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3381,7 +3391,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3408,7 +3418,8 @@
             },
             "post": {
                 "operationId": "objectinformatieobject_create",
-                "description": "",
+                "summary": "Maak een OBJECT-INFORMATIEOBJECT relatie aan.",
+                "description": "**LET OP: Dit endpoint hoor je als consumer niet zelf aan te spreken.**\n\nAndere API's, zoals de Zaken API en de Besluiten API, gebruiken dit\nendpoint bij het synchroniseren van relaties.\n\n**Er wordt gevalideerd op**\n- geldigheid `informatieobject` URL\n- de combinatie `informatieobject` en `object` moet uniek zijn\n- bestaan van `object` URL",
                 "parameters": [
                     {
                         "name": "data",
@@ -3442,7 +3453,7 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "",
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/ObjectInformatieObject"
                         },
@@ -3463,7 +3474,7 @@
                         }
                     },
                     "400": {
-                        "description": "",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ValidatieFout"
                         },
@@ -3477,7 +3488,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3491,7 +3502,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3505,7 +3516,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3519,7 +3530,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3533,7 +3544,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3547,7 +3558,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3561,7 +3572,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3575,7 +3586,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3605,11 +3616,12 @@
         "/objectinformatieobjecten/{uuid}": {
             "get": {
                 "operationId": "objectinformatieobject_read",
-                "description": "Geef een informatieobject terug wat gekoppeld is aan het huidige object",
+                "summary": "Een specifieke OBJECT-INFORMATIEOBJECT relatie opvragen.",
+                "description": "Een specifieke OBJECT-INFORMATIEOBJECT relatie opvragen.",
                 "parameters": [],
                 "responses": {
                     "200": {
-                        "description": "",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/ObjectInformatieObject"
                         },
@@ -3623,7 +3635,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3637,7 +3649,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3651,7 +3663,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3665,7 +3677,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3679,7 +3691,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3693,7 +3705,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3707,7 +3719,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3721,7 +3733,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3735,7 +3747,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3762,7 +3774,8 @@
             },
             "delete": {
                 "operationId": "objectinformatieobject_delete",
-                "description": "Verwijder een relatie tussen een object en een informatieobject.",
+                "summary": "Verwijder een OBJECT-INFORMATIEOBJECT relatie.",
+                "description": "**LET OP: Dit endpoint hoor je als consumer niet zelf aan te spreken.**\n\nAndere API's, zoals de Zaken API en de Besluiten API, gebruiken dit\nendpoint bij het synchroniseren van relaties.",
                 "parameters": [
                     {
                         "name": "X-NLX-Request-Application-Id",
@@ -3788,7 +3801,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "",
+                        "description": "No content",
                         "headers": {
                             "API-version": {
                                 "schema": {
@@ -3799,7 +3812,7 @@
                         }
                     },
                     "401": {
-                        "description": "",
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3813,7 +3826,7 @@
                         }
                     },
                     "403": {
-                        "description": "",
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3827,7 +3840,7 @@
                         }
                     },
                     "404": {
-                        "description": "",
+                        "description": "Not_found",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3841,7 +3854,7 @@
                         }
                     },
                     "406": {
-                        "description": "",
+                        "description": "Not acceptable",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3855,7 +3868,7 @@
                         }
                     },
                     "409": {
-                        "description": "",
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3869,7 +3882,7 @@
                         }
                     },
                     "410": {
-                        "description": "",
+                        "description": "Gone",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3883,7 +3896,7 @@
                         }
                     },
                     "415": {
-                        "description": "",
+                        "description": "Unsupported media type",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3897,7 +3910,7 @@
                         }
                     },
                     "429": {
-                        "description": "",
+                        "description": "Too many requests",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -3911,7 +3924,7 @@
                         }
                     },
                     "500": {
-                        "description": "",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/Fout"
                         },
@@ -4034,9 +4047,12 @@
             "properties": {
                 "url": {
                     "title": "Url",
+                    "description": "URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object.",
                     "type": "string",
                     "format": "uri",
-                    "readOnly": true
+                    "readOnly": true,
+                    "maxLength": 1000,
+                    "minLength": 1
                 },
                 "identificatie": {
                     "title": "Identificatie",
@@ -4099,13 +4115,13 @@
                 },
                 "formaat": {
                     "title": "Formaat",
-                    "description": "De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand.",
+                    "description": "Het \"Media Type\" (voorheen \"MIME type\") voor de wijze waaropde inhoud van het INFORMATIEOBJECT is vastgelegd in een computerbestand. Voorbeeld: `application/msword`.",
                     "type": "string",
                     "maxLength": 255
                 },
                 "taal": {
                     "title": "Taal",
-                    "description": "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B",
+                    "description": "Een taal van de intellectuele inhoud van het INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B",
                     "type": "string",
                     "enum": [
                         "aar",
@@ -4610,6 +4626,7 @@
                 },
                 "bestandsomvang": {
                     "title": "Bestandsomvang",
+                    "description": "Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.",
                     "type": "integer",
                     "readOnly": true,
                     "minimum": 0
@@ -4643,7 +4660,7 @@
                 },
                 "indicatieGebruiksrecht": {
                     "title": "Indicatie gebruiksrecht",
-                    "description": "Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag 'null' zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `Gebruiksrechten` resource.",
+                    "description": "Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag `null' zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `GEBRUIKSRECHTEN resource.",
                     "type": "boolean",
                     "x-nullable": true
                 },
@@ -4655,7 +4672,7 @@
                 },
                 "informatieobjecttype": {
                     "title": "Informatieobjecttype",
-                    "description": "URL naar de INFORMATIEOBJECTTYPE in het ZTC.",
+                    "description": "URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API).",
                     "type": "string",
                     "format": "uri",
                     "maxLength": 200,
@@ -4810,9 +4827,12 @@
             "properties": {
                 "url": {
                     "title": "Url",
+                    "description": "URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object.",
                     "type": "string",
                     "format": "uri",
-                    "readOnly": true
+                    "readOnly": true,
+                    "maxLength": 1000,
+                    "minLength": 1
                 },
                 "identificatie": {
                     "title": "Identificatie",
@@ -4875,13 +4895,13 @@
                 },
                 "formaat": {
                     "title": "Formaat",
-                    "description": "De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand.",
+                    "description": "Het \"Media Type\" (voorheen \"MIME type\") voor de wijze waaropde inhoud van het INFORMATIEOBJECT is vastgelegd in een computerbestand. Voorbeeld: `application/msword`.",
                     "type": "string",
                     "maxLength": 255
                 },
                 "taal": {
                     "title": "Taal",
-                    "description": "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B",
+                    "description": "Een taal van de intellectuele inhoud van het INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B",
                     "type": "string",
                     "enum": [
                         "aar",
@@ -5385,6 +5405,7 @@
                 },
                 "bestandsomvang": {
                     "title": "Bestandsomvang",
+                    "description": "Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.",
                     "type": "integer",
                     "readOnly": true,
                     "minimum": 0
@@ -5418,7 +5439,7 @@
                 },
                 "indicatie_gebruiksrecht": {
                     "title": "Indicatie gebruiksrecht",
-                    "description": "Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag 'null' zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `Gebruiksrechten` resource.",
+                    "description": "Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag `null' zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `GEBRUIKSRECHTEN resource.",
                     "type": "boolean",
                     "x-nullable": true
                 },
@@ -5430,7 +5451,7 @@
                 },
                 "informatieobjecttype": {
                     "title": "Informatieobjecttype",
-                    "description": "URL naar de INFORMATIEOBJECTTYPE in het ZTC.",
+                    "description": "URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API).",
                     "type": "string",
                     "format": "uri",
                     "maxLength": 200,
@@ -5598,9 +5619,12 @@
             "properties": {
                 "url": {
                     "title": "Url",
+                    "description": "URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object.",
                     "type": "string",
                     "format": "uri",
-                    "readOnly": true
+                    "readOnly": true,
+                    "maxLength": 1000,
+                    "minLength": 1
                 },
                 "identificatie": {
                     "title": "Identificatie",
@@ -5663,13 +5687,13 @@
                 },
                 "formaat": {
                     "title": "Formaat",
-                    "description": "De code voor de wijze waarop de inhoud van het ENKELVOUDIG INFORMATIEOBJECT is vastgelegd in een computerbestand.",
+                    "description": "Het \"Media Type\" (voorheen \"MIME type\") voor de wijze waaropde inhoud van het INFORMATIEOBJECT is vastgelegd in een computerbestand. Voorbeeld: `application/msword`.",
                     "type": "string",
                     "maxLength": 255
                 },
                 "taal": {
                     "title": "Taal",
-                    "description": "Een taal van de intellectuele inhoud van het ENKELVOUDIG INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B",
+                    "description": "Een taal van de intellectuele inhoud van het INFORMATIEOBJECT. De waardes komen uit ISO 639-2/B",
                     "type": "string",
                     "enum": [
                         "aar",
@@ -6173,6 +6197,7 @@
                 },
                 "bestandsomvang": {
                     "title": "Bestandsomvang",
+                    "description": "Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.",
                     "type": "integer",
                     "readOnly": true,
                     "minimum": 0
@@ -6206,7 +6231,7 @@
                 },
                 "indicatie_gebruiksrecht": {
                     "title": "Indicatie gebruiksrecht",
-                    "description": "Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag 'null' zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `Gebruiksrechten` resource.",
+                    "description": "Indicatie of er beperkingen gelden aangaande het gebruik van het informatieobject anders dan raadpleging. Dit veld mag `null' zijn om aan te geven dat de indicatie nog niet bekend is. Als de indicatie gezet is, dan kan je de gebruiksrechten die van toepassing zijn raadplegen via de `GEBRUIKSRECHTEN resource.",
                     "type": "boolean",
                     "x-nullable": true
                 },
@@ -6218,7 +6243,7 @@
                 },
                 "informatieobjecttype": {
                     "title": "Informatieobjecttype",
-                    "description": "URL naar de INFORMATIEOBJECTTYPE in het ZTC.",
+                    "description": "URL-referentie naar het INFORMATIEOBJECTTYPE (in de Catalogi API).",
                     "type": "string",
                     "format": "uri",
                     "maxLength": 200,
@@ -6271,12 +6296,16 @@
             "properties": {
                 "url": {
                     "title": "Url",
+                    "description": "URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object.",
                     "type": "string",
                     "format": "uri",
-                    "readOnly": true
+                    "readOnly": true,
+                    "maxLength": 1000,
+                    "minLength": 1
                 },
                 "informatieobject": {
                     "title": "Informatieobject",
+                    "description": "URL-referentie naar het INFORMATIEOBJECT.",
                     "type": "string",
                     "format": "uri"
                 },
@@ -6311,18 +6340,22 @@
             "properties": {
                 "url": {
                     "title": "Url",
+                    "description": "URL-referentie naar dit object. Dit is de unieke identificatie en locatie van dit object.",
                     "type": "string",
                     "format": "uri",
-                    "readOnly": true
+                    "readOnly": true,
+                    "maxLength": 1000,
+                    "minLength": 1
                 },
                 "informatieobject": {
                     "title": "Informatieobject",
+                    "description": "URL-referentie naar het INFORMATIEOBJECT.",
                     "type": "string",
                     "format": "uri"
                 },
                 "object": {
                     "title": "Object",
-                    "description": "URL naar het gerelateerde OBJECT.",
+                    "description": "URL-referentie naar het gerelateerde OBJECT (in deze of een andere API).",
                     "type": "string",
                     "format": "uri",
                     "maxLength": 200,
@@ -6330,6 +6363,7 @@
                 },
                 "objectType": {
                     "title": "Objecttype",
+                    "description": "Het type van het gerelateerde OBJECT.",
                     "type": "string",
                     "enum": [
                         "besluit",


### PR DESCRIPTION
Depends on: https://github.com/VNG-Realisatie/vng-api-common/pull/74

One issue left but cannot find the exact reason: POST/PUT/PATCH use the non-camelcase version of `indicatie_gebruiksrecht`. GET shows it correctly. It must be about using customizations for these methods but... @sergei-maertens any idea?