### PR TITLE
add MIN_UPLOAD_SIZE to config and docs

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -12,6 +12,7 @@ db_port=${DB_PORT:-5432}
 fixtures_dir=${FIXTURES_DIR:-/app/fixtures}
 
 uwsgi_port=${UWSGI_PORT:-8000}
+min_upload_size=${MIN_UPLOAD_SIZE:-4294967296}
 
 until PGPORT=$db_port PGPASSWORD=$db_password psql -h "$db_host" -U "$db_user" -c '\q'; do
   >&2 echo "Waiting for database connection..."
@@ -46,5 +47,6 @@ uwsgi \
     --chdir src \
     --processes 2 \
     --threads 2 \
-    --buffer-size=32768
+    --buffer-size=32768 \
+    --limit-post=$min_upload_size
     # processes & threads are needed for concurrency without nginx sitting inbetween

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,9 @@ services:
     ports:
       - 8000:80
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/default.conf:/etc/nginx/conf.d/mysite.template
+    environment:
+      - MIN_UPLOAD_SIZE=4294967296
+    command: /bin/bash -c "envsubst '$$MIN_UPLOAD_SIZE' < /etc/nginx/conf.d/mysite.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"
     depends_on:
       - web
-#    volumes:
-#      - ./nginx/default.conf:/etc/nginx/conf.d/mysite.template
-#    environment:
-#      - MIN_UPLOAD_SIZE=4294967296
-#    command: /bin/bash -c "envsubst < /etc/nginx/conf.d/mysite.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,8 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - web
+#    volumes:
+#      - ./nginx/default.conf:/etc/nginx/conf.d/mysite.template
+#    environment:
+#      - MIN_UPLOAD_SIZE=4294967296
+#    command: /bin/bash -c "envsubst < /etc/nginx/conf.d/mysite.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,7 @@
 server {
     listen       80;
     server_name  localhost;
+    # client_max_body_size ${"MIN_UPLOAD_SIZE"};
 
     location / {
         proxy_pass http://web:8000;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,7 +1,7 @@
 server {
     listen       80;
     server_name  localhost;
-    # client_max_body_size ${"MIN_UPLOAD_SIZE"};
+    client_max_body_size ${MIN_UPLOAD_SIZE};
 
     location / {
         proxy_pass http://web:8000;

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -23,3 +23,4 @@ djangorestframework-camel-case
 djangorestframework-filters
 drf-yasg
 vng-api-common
+humanize

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,6 +31,7 @@ drf-nested-routers==0.90.2  # via vng-api-common
 drf-yasg==1.16.0
 first==2.0.1              # via pip-tools
 gemma-zds-client==0.11.0  # via vng-api-common
+humanize==0.5.1
 idna==2.7                 # via requests
 imagesize==1.1.0          # via sphinx
 inflection==0.3.1         # via drf-yasg

--- a/requirements/jenkins.txt
+++ b/requirements/jenkins.txt
@@ -40,6 +40,7 @@ faker==0.8.17             # via factory-boy
 first==2.0.1
 freezegun==0.3.10
 gemma-zds-client==0.11.0
+humanize==0.5.1
 idna==2.7
 imagesize==1.1.0
 inflection==0.3.1

--- a/src/drc/api/serializers.py
+++ b/src/drc/api/serializers.py
@@ -137,7 +137,10 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
         view_name='enkelvoudiginformatieobject-detail',
         lookup_field='uuid'
     )
-    inhoud = AnyBase64File(view_name='enkelvoudiginformatieobject-download')
+    inhoud = AnyBase64File(
+        view_name='enkelvoudiginformatieobject-download',
+        help_text=_(f"Minimal accepted size of uploaded file = {settings.MIN_UPLOAD_SIZE} bytes")
+    )
     bestandsomvang = serializers.IntegerField(
         source='inhoud.size', read_only=True, min_value=0,
         help_text=_("Aantal bytes dat de inhoud van INFORMATIEOBJECT in beslag neemt.")

--- a/src/drc/api/serializers.py
+++ b/src/drc/api/serializers.py
@@ -2,6 +2,7 @@
 Serializers of the Document Registratie Component REST API
 """
 import uuid
+from humanize import naturalsize
 
 from django.conf import settings
 from django.db import transaction
@@ -139,7 +140,8 @@ class EnkelvoudigInformatieObjectSerializer(serializers.HyperlinkedModelSerializ
     )
     inhoud = AnyBase64File(
         view_name='enkelvoudiginformatieobject-download',
-        help_text=_(f"Minimal accepted size of uploaded file = {settings.MIN_UPLOAD_SIZE} bytes")
+        help_text=_(f"Minimal accepted size of uploaded file = {settings.MIN_UPLOAD_SIZE} bytes "
+                    f"(or {naturalsize(settings.MIN_UPLOAD_SIZE, binary=True)})")
     )
     bestandsomvang = serializers.IntegerField(
         source='inhoud.size', read_only=True, min_value=0,

--- a/src/drc/api/viewsets.py
+++ b/src/drc/api/viewsets.py
@@ -1,7 +1,4 @@
 from django.db import transaction
-from django.http.response import Http404
-from django.shortcuts import get_list_or_404, get_object_or_404
-from django.utils import dateparse, timezone
 from django.utils.translation import ugettext_lazy as _
 
 from drf_yasg import openapi
@@ -16,7 +13,6 @@ from vng_api_common.audittrails.viewsets import (
     AuditTrailCreateMixin, AuditTrailDestroyMixin, AuditTrailViewSet,
     AuditTrailViewsetMixin
 )
-from vng_api_common.filters import Backend
 from vng_api_common.notifications.viewsets import (
     NotificationCreateMixin, NotificationDestroyMixin,
     NotificationViewSetMixin
@@ -25,8 +21,7 @@ from vng_api_common.serializers import FoutSerializer
 from vng_api_common.viewsets import CheckQueryParamsMixin
 
 from drc.datamodel.models import (
-    EnkelvoudigInformatieObject, EnkelvoudigInformatieObjectCanonical,
-    Gebruiksrechten, ObjectInformatieObject
+    EnkelvoudigInformatieObject, Gebruiksrechten, ObjectInformatieObject
 )
 
 from .audits import AUDIT_DRC

--- a/src/drc/conf/base.py
+++ b/src/drc/conf/base.py
@@ -385,3 +385,6 @@ PRIVATE_MEDIA_URL = '/private-media/'
 SENDFILE_BACKEND = 'sendfile.backends.simple'
 SENDFILE_ROOT = PRIVATE_MEDIA_ROOT
 SENDFILE_URL = PRIVATE_MEDIA_URL
+
+# settings for uploading large files
+MIN_UPLOAD_SIZE = int(os.getenv('MIN_UPLOAD_SIZE', 4 * 2**30))


### PR DESCRIPTION
Issue - https://github.com/VNG-Realisatie/gemma-zaken/issues/1211 

**Changes:**
1. Add MIN_UPLOAD_SIZE as an environment var to config and docs

**Note:**
1. Currently file size is not shown in the schema, because `help_text` is overwritten by the file inspector in `vng_api_common`
This could be fixed either in the file inspector or after merging PR https://github.com/VNG-Realisatie/gemma-documentregistratiecomponent/pull/68, there the type of the field is changed